### PR TITLE
Fix mini audio player height AIC-637

### DIFF
--- a/aic/aic/Shared/Common.swift
+++ b/aic/aic/Shared/Common.swift
@@ -173,7 +173,7 @@ struct Common {
 		}
 		
 		static var tabBarHeight: CGFloat {
-			if UIDevice().type == .iPhoneX {
+            if UIDevice().type == .iPhoneX || UIDevice().type == .iPhoneXS || UIDevice().type == .iPhoneXS_Max || UIDevice().type == .iPhoneXR {
 				return 83
 			}
 			return 49

--- a/aic/aic/Shared/UIDevice+Model.swift
+++ b/aic/aic/Shared/UIDevice+Model.swift
@@ -43,8 +43,11 @@ public enum Model : String {
 	iPhone7plus      = "iPhone 7 Plus",
 	iPhone8          = "iPhone 8",
 	iPhone8plus      = "iPhone 8 Plus",
-	iPhoneX          = "iPhone X",
-	unrecognized     = "?unrecognized?"
+    iPhoneX          = "iPhone X",
+    iPhoneXS         = "iPhone XS",
+    iPhoneXS_Max     = "iPhone XS Max",
+    iPhoneXR         = "iPhone XR",
+    unrecognized     = "?unrecognized?"
 }
 
 public extension UIDevice {
@@ -120,7 +123,10 @@ public extension UIDevice {
 			"iPhone10,3" : .iPhoneX,
 			"iPhone10,4" : .iPhone8,
 			"iPhone10,5" : .iPhone8plus,
-			"iPhone10,6" : .iPhoneX,
+            "iPhone10,6" : .iPhoneX,
+            "iPhone11,2" : .iPhoneXS,
+            "iPhone11,4" : .iPhoneXS_Max,
+            "iPhone11,8" : .iPhoneXR
 		]
 		
 		if let model = modelMap[String(validatingUTF8: modelCode)!] {


### PR DESCRIPTION
@nicktrienensfuzz 
I added new iPhone device types, which a user may be using, and ensured the same `tabBarHeight` value is returned as that of the iPhoneX, which was already in codebase. 