### PR TITLE
fix color behind opening animation AIC-639

### DIFF
--- a/aic/aic/ViewControllers+Views/Loading/LoadingViewController.swift
+++ b/aic/aic/ViewControllers+Views/Loading/LoadingViewController.swift
@@ -53,8 +53,8 @@ class LoadingViewController: UIViewController {
 				resolutionString = String(height)
 			case 2208:
 				resolutionString = String(height)
-			case 2436:
-				resolutionString = String(height)
+			case 2436, 1624: // 1624 is the height for XR, and this video is only video that will work for XR
+				resolutionString = "2436"
 			default:
 				resolutionString = "1334"
 			}


### PR DESCRIPTION
@nicktrienensfuzz I ensured that when user's device being used is XR device, it returns the same start video being used for iPhone X devices. 