### PR TITLE
Fix attributed string crash caused by Swift 5 migration

### DIFF
--- a/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/EventContentCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/EventContentCell.swift
@@ -38,7 +38,7 @@ class EventContentCell: UITableViewCell {
 		hoursMinutesLabel.font = .aicInfoOverlayFont
 		transparentOverlayView.backgroundColor = UIColor(white: 0.0, alpha: 0.5)
 		descriptionTextView.setDefaultsForAICAttributedTextView()
-		descriptionTextView.linkTextAttributes = [.foregroundColor: UIColor.white, .underlineStyle: NSUnderlineStyle.single]
+		descriptionTextView.linkTextAttributes = [.foregroundColor: UIColor.white, .underlineStyle: NSUnderlineStyle.single.rawValue]
 		locationAndDateLabel.numberOfLines = 2
 	}
 

--- a/aic/aic/ViewControllers+Views/Sections/Search Card/Table View Cells/NoResultsCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Search Card/Table View Cells/NoResultsCell.swift
@@ -47,7 +47,7 @@ class NoResultsCell: UITableViewCell {
 		let visitOurWebsiteAttrString = NSMutableAttributedString(string: visitWebsiteText)
 		let websiteURL = URL(string: AppDataManager.sharedInstance.app.dataSettings[.websiteUrl]!)!
 		visitOurWebsiteAttrString.addAttributes([.link: websiteURL.absoluteString], range: NSRange(location: 0, length: visitOurWebsiteAttrString.string.count))
-		visitOurWebsiteAttrString.addAttributes([.underlineStyle: NSUnderlineStyle.single], range: linkRange)
+		visitOurWebsiteAttrString.addAttributes([.underlineStyle: NSUnderlineStyle.single.rawValue], range: linkRange)
 
 		visitWebsiteTextView.attributedText = visitOurWebsiteAttrString
 		visitWebsiteTextView.textColor = .aicCardDarkLinkColor


### PR DESCRIPTION
This pull request fixes a crash that was occurring with `NSUnderlineStyle` attributes in an `NSAttributedString`.