### PR TITLE
Map zoom fix

### DIFF
--- a/aic/aic/ViewControllers+Views/RootViewController.swift
+++ b/aic/aic/ViewControllers+Views/RootViewController.swift
@@ -36,7 +36,7 @@ final class RootViewController: UIViewController {
   }()
 
   private lazy var sectionTabBarController: SectionsViewController = {
-    let viewController = SectionsViewController()
+    let viewController = SectionsViewController(nibName: nil, bundle: nil)
     viewController.sectionTabBarDelegate = self
     return viewController
   }()

--- a/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
@@ -168,7 +168,7 @@ class MapView: MKMapView {
 	func keepMapInView(zoomLimit: Double) {
 		// Check altitude
 		if currentAltitude > zoomLimit {
-			showFullMap(centerCoordinateDistance: zoomLimit)
+            showFullMap(centerCoordinateDistance: Common.Map.ZoomLevelAltitude.zoomDefault.rawValue + 5)
             debugPrint("MapView.keepMapInView zoomLimit: \(zoomLimit)")
 		} else {
 			// Make sure our floorplan is on-screen


### PR DESCRIPTION
When the zoom limit is exceed, reset back to the default + 5 meters.

Panning to the right (south) causes the zoom level to increases ever so slightly. When the value is reset to the exact zoom limit, this can lead to the unwanted behavior of the map re-zooming (which appears to just be re-centering) when the user pans to the right.

The additional five meters is added to prevent the gallery labels from being displayed, which occurs at the default zoom level.