### PR TITLE
Fix compass button tap-to-recenter delay

### DIFF
--- a/aic/aic/ViewControllers+Views/Sections/Map/MapViewController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapViewController.swift
@@ -980,6 +980,11 @@ extension MapViewController: MapFloorSelectorViewControllerDelegate {
 				floorSelectorViewController.disableUserHeading()
 			} else {
 				floorSelectorViewController.enableUserHeading()
+                
+                // Attempt to re-center on the device's last known location.
+                if let lastKnownCoordinate = Common.Map.locationManager.location?.coordinate {
+                    mapView.zoomIn(onCenterCoordinate: lastKnownCoordinate)
+                }
 
 				// Log Analytics
 				AICAnalytics.sendLocationEnableHeadingEvent()


### PR DESCRIPTION
When the compass button is tapped to recenter to the device's location, try to move to the last know location immediately. This should help avoid the situation where there could be a delay if the location updates are not being received frequently.