### PR TITLE
Audio tour not exiting fix

### DIFF
--- a/aic/aic/ViewControllers+Views/Sections/Audio Player Card/AudioPlayerNavigationController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Audio Player Card/AudioPlayerNavigationController.swift
@@ -783,7 +783,8 @@ extension AudioPlayerNavigationController {
 		_ = pause()
 		hide()
 		currentAudioFile = nil
-		// TODO: remove track from MPNowPlayingInfoCenter and RemoteControl
+        
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
 	}
 
 	@objc func miniAudioPlayerTapped() {

--- a/aic/aic/ViewControllers+Views/Sections/SectionsViewController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/SectionsViewController.swift
@@ -607,6 +607,9 @@ extension SectionsViewController: MessageViewControllerDelegate {
 
 			showRequestedMapContentIfNeeded()
 			resetRequestedMapContent()
+            
+            // Stop the audio using the existing mini-player logic
+            audioPlayerCardVC.miniAudioPlayerCloseButtonPressed(button: UIButton())
 
 			if let messages = tourNid.map({ AppDataManager.sharedInstance.getTourExitMessages(for: "\($0)") }),
 				messages.count > 0 {


### PR DESCRIPTION
When leaving a tour, make sure that the audio playback is stopped using the existing function used by the mini player.

This also removes the metadata from the NowPlayingInfoCenter so that it won't continue to show on the Lock Screen.