### PR TITLE
Display location information for debugging

### DIFF
--- a/aic/aic/ViewControllers+Views/Sections/Info/LocationSettingsViewController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Info/LocationSettingsViewController.swift
@@ -76,6 +76,18 @@ class LocationSettingsViewController: UIViewController {
 	@objc func updateLanguage() {
 		pageView.titleLabel.text = "location_settings_header".localized(using: "LocationUI")
 		pageView.textView.text = "location_settings_body".localized(using: "LocationUI")
+        
+        // Location Debug Information
+        if let location = Common.Map.locationManager.location {
+            pageView.textView.text += """
+            \n
+            \n
+            Location Debug Information:
+            \(location.coordinate.latitude), \(location.coordinate.longitude)
+            Accuracy: \(Int(location.horizontalAccuracy)) meters
+            Last updated: \(DateFormatter.localizedString(from: location.timestamp, dateStyle: .short, timeStyle: .short))
+            """
+        }
 
 		if CLLocationManager.locationServicesEnabled() {
 			switch locationManager.authorizationStatus {


### PR DESCRIPTION
This displays information about the most recent location update on the `Location Settings` page. This can hopefully be used to help troubleshoot location problems in the museum while the app is being used. 

This is just for debugging and will be removed before shipping to the App Store.