### PR TITLE
Adjust constraints to prevent button text from truncating.

### DIFF
--- a/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ArtworkContentCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ArtworkContentCell.swift
@@ -19,7 +19,6 @@ class ArtworkContentCell: UITableViewCell {
 	@IBOutlet weak var descriptionLabel: UILabel!
 
 	@IBOutlet var artworkImageHeight: NSLayoutConstraint!
-	@IBOutlet weak var showOnMapButtonHorizontalOffset: NSLayoutConstraint!
 
 	override func awakeFromNib() {
 		super.awakeFromNib()
@@ -31,8 +30,6 @@ class ArtworkContentCell: UITableViewCell {
 		artworkImageView.backgroundColor = .clear
 		artworkImageView.contentMode = .scaleAspectFit
 		artworkImageView.clipsToBounds = true
-		showOnMapButton.setIconImage(image: #imageLiteral(resourceName: "buttonMapIcon"))
-		playAudioButton.setIconImage(image: #imageLiteral(resourceName: "buttonPlayIcon"))
 		showOnMapButton.titleLabel?.font = .aicButtonFont
 		playAudioButton.titleLabel?.font = .aicButtonFont
 		artistDisplayLabel.font = .aicTextFont
@@ -70,7 +67,6 @@ class ArtworkContentCell: UITableViewCell {
 			} else {
 				playAudioButton.isHidden = true
 				playAudioButton.isEnabled = false
-				showOnMapButtonHorizontalOffset.constant = 0
 				self.setNeedsLayout()
 				self.layoutIfNeeded()
 			}

--- a/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ArtworkContentCell.xib
+++ b/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ArtworkContentCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -22,30 +22,39 @@
                             <constraint firstAttribute="height" constant="344" id="SVl-du-zgM"/>
                         </constraints>
                     </imageView>
-                    <button autoresizesSubviews="NO" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DkG-Tn-HfR" customClass="AICButton" customModule="aic" customModuleProvider="target">
-                        <rect key="frame" x="39.5" y="360" width="140" height="50"/>
-                        <color key="backgroundColor" red="0.2156862745" green="0.63529411759999999" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="140" id="6aO-TF-scf"/>
-                            <constraint firstAttribute="height" constant="50" id="sml-Sa-sPx"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                        <state key="normal" title="Show On Map">
-                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        </state>
-                    </button>
-                    <button autoresizesSubviews="NO" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yUV-LP-EGt" customClass="AICButton" customModule="aic" customModuleProvider="target">
-                        <rect key="frame" x="195.5" y="360" width="140" height="50"/>
-                        <color key="backgroundColor" red="0.2156862745" green="0.63529411759999999" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="140" id="NJS-yZ-yxc"/>
-                            <constraint firstAttribute="height" constant="50" id="boM-MK-SS3"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                        <state key="normal" title="Play Audio">
-                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        </state>
-                    </button>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="o9F-06-MNv">
+                        <rect key="frame" x="39.5" y="360" width="296" height="50"/>
+                        <subviews>
+                            <button autoresizesSubviews="NO" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DkG-Tn-HfR" customClass="AICButton" customModule="aic" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="140" height="50"/>
+                                <color key="backgroundColor" red="0.2156862745" green="0.63529411759999999" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="mEa-Uq-4zV"/>
+                                    <constraint firstAttribute="height" constant="50" id="sml-Sa-sPx"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="20" maxY="0.0"/>
+                                <inset key="titleEdgeInsets" minX="10" minY="0.0" maxX="-10" maxY="0.0"/>
+                                <state key="normal" title="Show On Map" image="buttonMapIcon">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
+                            <button autoresizesSubviews="NO" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yUV-LP-EGt" customClass="AICButton" customModule="aic" customModuleProvider="target">
+                                <rect key="frame" x="156" y="0.0" width="140" height="50"/>
+                                <color key="backgroundColor" red="0.2156862745" green="0.63529411759999999" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="VgR-kz-5bz"/>
+                                    <constraint firstAttribute="height" constant="50" id="boM-MK-SS3"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="20" maxY="0.0"/>
+                                <inset key="titleEdgeInsets" minX="10" minY="0.0" maxX="-10" maxY="0.0"/>
+                                <state key="normal" title="Play Audio" image="buttonPlayIcon">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
+                        </subviews>
+                    </stackView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Artist Display" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b7E-yS-5QK" customClass="UILabelPadding" customModule="aic" customModuleProvider="target">
                         <rect key="frame" x="16" y="437" width="343" height="19.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -76,23 +85,23 @@
                     </label>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="o9F-06-MNv" secondAttribute="trailing" constant="16" id="2hu-9m-A2g"/>
                     <constraint firstItem="b7E-yS-5QK" firstAttribute="top" secondItem="0gb-q7-Ckj" secondAttribute="bottom" constant="93" id="3Yl-yL-DTe"/>
                     <constraint firstItem="VuV-uX-a1H" firstAttribute="top" secondItem="mwj-gT-Q05" secondAttribute="bottom" constant="32" id="52o-Uo-f9B"/>
                     <constraint firstAttribute="trailing" secondItem="b7E-yS-5QK" secondAttribute="trailing" constant="16" id="8Ek-Kx-EH1"/>
+                    <constraint firstItem="o9F-06-MNv" firstAttribute="centerX" secondItem="FZo-ir-nod" secondAttribute="centerX" id="Hd3-1T-XuO"/>
                     <constraint firstAttribute="bottom" secondItem="jCz-Ae-RrX" secondAttribute="bottom" constant="30.5" id="KX2-0q-qFj"/>
                     <constraint firstItem="b7E-yS-5QK" firstAttribute="leading" secondItem="FZo-ir-nod" secondAttribute="leading" constant="16" id="LaF-Ty-vT5"/>
                     <constraint firstItem="0gb-q7-Ckj" firstAttribute="centerX" secondItem="FZo-ir-nod" secondAttribute="centerX" id="Lsy-2t-DPd"/>
-                    <constraint firstItem="yUV-LP-EGt" firstAttribute="centerX" secondItem="FZo-ir-nod" secondAttribute="centerX" constant="78" id="QSl-dl-oLF"/>
+                    <constraint firstItem="o9F-06-MNv" firstAttribute="top" secondItem="0gb-q7-Ckj" secondAttribute="bottom" constant="16" id="O2Z-ft-mL1"/>
+                    <constraint firstItem="o9F-06-MNv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="FZo-ir-nod" secondAttribute="leading" constant="16" id="Tcy-t0-bvE"/>
                     <constraint firstItem="jCz-Ae-RrX" firstAttribute="leading" secondItem="FZo-ir-nod" secondAttribute="leading" constant="16" id="UdF-si-Gak"/>
-                    <constraint firstItem="yUV-LP-EGt" firstAttribute="top" secondItem="0gb-q7-Ckj" secondAttribute="bottom" constant="16" id="YPb-iW-WNw"/>
                     <constraint firstAttribute="trailing" secondItem="0gb-q7-Ckj" secondAttribute="trailing" constant="16" id="ajs-IU-dpg"/>
                     <constraint firstAttribute="trailing" secondItem="mwj-gT-Q05" secondAttribute="trailing" constant="16" id="b1q-X7-CKo"/>
                     <constraint firstItem="mwj-gT-Q05" firstAttribute="top" secondItem="b7E-yS-5QK" secondAttribute="bottom" constant="8" id="fP5-ik-X8X"/>
                     <constraint firstItem="0gb-q7-Ckj" firstAttribute="leading" secondItem="FZo-ir-nod" secondAttribute="leading" constant="16" id="fTX-iT-Has"/>
-                    <constraint firstItem="DkG-Tn-HfR" firstAttribute="top" secondItem="0gb-q7-Ckj" secondAttribute="bottom" constant="16" id="j1L-eH-v2r"/>
                     <constraint firstAttribute="trailing" secondItem="VuV-uX-a1H" secondAttribute="trailing" constant="16" id="oTF-5l-EbA"/>
                     <constraint firstItem="0gb-q7-Ckj" firstAttribute="top" secondItem="FZo-ir-nod" secondAttribute="top" id="qtu-Lt-sNl"/>
-                    <constraint firstItem="DkG-Tn-HfR" firstAttribute="centerX" secondItem="FZo-ir-nod" secondAttribute="centerX" constant="-78" id="tM1-Yw-oiu"/>
                     <constraint firstItem="mwj-gT-Q05" firstAttribute="leading" secondItem="FZo-ir-nod" secondAttribute="leading" constant="16" id="us3-go-E0s"/>
                     <constraint firstAttribute="trailing" secondItem="jCz-Ae-RrX" secondAttribute="trailing" constant="16" id="vWt-dB-SMt"/>
                     <constraint firstItem="jCz-Ae-RrX" firstAttribute="top" secondItem="VuV-uX-a1H" secondAttribute="bottom" constant="20" id="wk5-nZ-404"/>
@@ -108,9 +117,12 @@
                 <outlet property="galleryTitleLabel" destination="mwj-gT-Q05" id="mzR-ug-8Og"/>
                 <outlet property="playAudioButton" destination="yUV-LP-EGt" id="Lh1-bw-AXb"/>
                 <outlet property="showOnMapButton" destination="DkG-Tn-HfR" id="ffm-8Y-dkk"/>
-                <outlet property="showOnMapButtonHorizontalOffset" destination="tM1-Yw-oiu" id="2ze-bZ-jA8"/>
             </connections>
             <point key="canvasLocation" x="34.399999999999999" y="277.51124437781112"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="buttonMapIcon" width="25" height="25"/>
+        <image name="buttonPlayIcon" width="25" height="25"/>
+    </resources>
 </document>

--- a/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ExhibitionContentCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ExhibitionContentCell.swift
@@ -20,9 +20,6 @@ class ExhibitionContentCell: UITableViewCell {
 	@IBOutlet var galleryTitleLabel: UILabel!
 	@IBOutlet var throughDateLabel: UILabel!
 
-	@IBOutlet weak var showOnMapButtonHorizontalOffset: NSLayoutConstraint!
-	@IBOutlet weak var buyTicketsButtonHorizontalOffset: NSLayoutConstraint!
-
 	override func awakeFromNib() {
 		super.awakeFromNib()
 
@@ -32,8 +29,6 @@ class ExhibitionContentCell: UITableViewCell {
 
 		exhibitionImageView.contentMode = .scaleAspectFill
 		exhibitionImageView.clipsToBounds = true
-		showOnMapButton.setIconImage(image: #imageLiteral(resourceName: "buttonMapIcon"))
-		buyTicketsButton.setIconImage(image: #imageLiteral(resourceName: "buttonTicketIcon"))
 		showOnMapButton.titleLabel?.font = .aicButtonFont
 		buyTicketsButton.titleLabel?.font = .aicButtonFont
 		descriptionLabel.font = .aicTextFont
@@ -92,7 +87,6 @@ class ExhibitionContentCell: UITableViewCell {
 			if exhibitionModel.location == nil {
 				showOnMapButton.isHidden = true
 				showOnMapButton.isEnabled = false
-				buyTicketsButtonHorizontalOffset.constant = 0
 			} else if let showOnMapButton = showOnMapButton {
 				accessibilityItems.append(showOnMapButton)
 			}

--- a/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ExhibitionContentCell.xib
+++ b/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ExhibitionContentCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -22,30 +22,39 @@
                             <constraint firstAttribute="width" secondItem="Zhx-kn-QDT" secondAttribute="height" multiplier="25:24" id="5T5-T0-EtO"/>
                         </constraints>
                     </imageView>
-                    <button autoresizesSubviews="NO" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pPS-6o-axa" customClass="AICButton" customModule="aic" customModuleProvider="target">
-                        <rect key="frame" x="39.5" y="376" width="140" height="50"/>
-                        <color key="backgroundColor" red="0.2156862745" green="0.63529411759999999" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="50" id="5cY-Y3-1dm"/>
-                            <constraint firstAttribute="width" constant="140" id="cbl-bp-8wu"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                        <state key="normal" title="Show On Map">
-                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        </state>
-                    </button>
-                    <button autoresizesSubviews="NO" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B1T-B2-Jzi" customClass="AICButton" customModule="aic" customModuleProvider="target">
-                        <rect key="frame" x="195.5" y="376" width="140" height="50"/>
-                        <color key="backgroundColor" red="0.2156862745" green="0.63529411759999999" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="50" id="XuC-VA-ea4"/>
-                            <constraint firstAttribute="width" constant="140" id="yJB-H8-DjY"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                        <state key="normal" title="Buy Tickets">
-                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        </state>
-                    </button>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="RFd-Xg-xgk">
+                        <rect key="frame" x="39.5" y="376" width="296" height="50"/>
+                        <subviews>
+                            <button autoresizesSubviews="NO" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pPS-6o-axa" customClass="AICButton" customModule="aic" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="140" height="50"/>
+                                <color key="backgroundColor" red="0.2156862745" green="0.63529411759999999" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="5cY-Y3-1dm"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="cbl-bp-8wu"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="20" maxY="0.0"/>
+                                <inset key="titleEdgeInsets" minX="10" minY="0.0" maxX="-10" maxY="0.0"/>
+                                <state key="normal" title="Show On Map" image="buttonMapIcon">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
+                            <button autoresizesSubviews="NO" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B1T-B2-Jzi" customClass="AICButton" customModule="aic" customModuleProvider="target">
+                                <rect key="frame" x="156" y="0.0" width="140" height="50"/>
+                                <color key="backgroundColor" red="0.2156862745" green="0.63529411759999999" blue="0.64705882349999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="XuC-VA-ea4"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="a36-KZ-1QS"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="20" maxY="0.0"/>
+                                <inset key="titleEdgeInsets" minX="10" minY="0.0" maxX="-10" maxY="0.0"/>
+                                <state key="normal" title="Buy Tickets" image="buttonTicketIcon">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
+                        </subviews>
+                    </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="ajj-Mb-KWS">
                         <rect key="frame" x="16" y="453" width="343" height="139"/>
                         <subviews>
@@ -77,29 +86,31 @@
                     <constraint firstAttribute="trailing" secondItem="Zhx-kn-QDT" secondAttribute="trailing" id="1mF-mK-vgw"/>
                     <constraint firstItem="ajj-Mb-KWS" firstAttribute="top" secondItem="Zhx-kn-QDT" secondAttribute="bottom" constant="93" id="3ZT-pw-Zxt"/>
                     <constraint firstAttribute="bottom" secondItem="ajj-Mb-KWS" secondAttribute="bottom" id="55T-ns-CpZ"/>
-                    <constraint firstItem="B1T-B2-Jzi" firstAttribute="top" secondItem="Zhx-kn-QDT" secondAttribute="bottom" constant="16" id="BGB-rF-4Tp"/>
-                    <constraint firstItem="pPS-6o-axa" firstAttribute="centerX" secondItem="mLP-V2-pYH" secondAttribute="centerX" constant="-78" id="Dt4-bW-jQN"/>
+                    <constraint firstItem="RFd-Xg-xgk" firstAttribute="top" secondItem="Zhx-kn-QDT" secondAttribute="bottom" constant="16" id="Bje-Ow-lC9"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="RFd-Xg-xgk" secondAttribute="trailing" constant="16" id="J3m-Lb-oqe"/>
                     <constraint firstAttribute="trailing" secondItem="ajj-Mb-KWS" secondAttribute="trailing" constant="16" id="KaC-ed-akB"/>
                     <constraint firstItem="Zhx-kn-QDT" firstAttribute="leading" secondItem="mLP-V2-pYH" secondAttribute="leading" id="LMI-rI-roE"/>
                     <constraint firstItem="Zhx-kn-QDT" firstAttribute="centerX" secondItem="mLP-V2-pYH" secondAttribute="centerX" id="VyZ-4h-xac"/>
+                    <constraint firstItem="RFd-Xg-xgk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="mLP-V2-pYH" secondAttribute="leading" constant="16" id="cjG-l0-4p4"/>
                     <constraint firstItem="Zhx-kn-QDT" firstAttribute="top" secondItem="mLP-V2-pYH" secondAttribute="top" id="fd9-We-uYR"/>
-                    <constraint firstItem="pPS-6o-axa" firstAttribute="top" secondItem="Zhx-kn-QDT" secondAttribute="bottom" constant="16" id="noq-C4-Ad8"/>
-                    <constraint firstItem="B1T-B2-Jzi" firstAttribute="centerX" secondItem="mLP-V2-pYH" secondAttribute="centerX" constant="78" id="oCy-td-9t8"/>
+                    <constraint firstItem="RFd-Xg-xgk" firstAttribute="centerX" secondItem="mLP-V2-pYH" secondAttribute="centerX" id="hrZ-zc-1dU"/>
                     <constraint firstItem="ajj-Mb-KWS" firstAttribute="leading" secondItem="mLP-V2-pYH" secondAttribute="leading" constant="16" id="zr9-ND-Jsh"/>
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="calibratedRGB"/>
             <connections>
                 <outlet property="buyTicketsButton" destination="B1T-B2-Jzi" id="arm-p6-ITN"/>
-                <outlet property="buyTicketsButtonHorizontalOffset" destination="oCy-td-9t8" id="frN-Md-Nnz"/>
                 <outlet property="descriptionLabel" destination="DlE-mQ-422" id="7qc-pM-tV9"/>
                 <outlet property="exhibitionImageView" destination="Zhx-kn-QDT" id="DYR-hF-yKX"/>
                 <outlet property="galleryTitleLabel" destination="brR-Tg-NaN" id="Crk-Bx-kw6"/>
                 <outlet property="showOnMapButton" destination="pPS-6o-axa" id="LkO-0j-NfG"/>
-                <outlet property="showOnMapButtonHorizontalOffset" destination="Dt4-bW-jQN" id="tF9-bH-Ywo"/>
                 <outlet property="throughDateLabel" destination="08c-cl-LXS" id="LDe-n8-mgS"/>
             </connections>
             <point key="canvasLocation" x="2.3999999999999999" y="181.70914542728636"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="buttonMapIcon" width="25" height="25"/>
+        <image name="buttonTicketIcon" width="25" height="25"/>
+    </resources>
 </document>


### PR DESCRIPTION
This adjusts the constraints for buttons on both the Artwork and Exhibition cards from being a fixed width of 140, to being a minimum of 140 with the option to expand horizontally as needed to fit the text.