### PR TITLE
Fix number pad "Go" button truncation.

### DIFF
--- a/aic/aic/ViewControllers+Views/Sections/AudioGuide/AudioGuideCollectionViewCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/AudioGuide/AudioGuideCollectionViewCell.swift
@@ -20,6 +20,7 @@ class AudioGuideCollectionViewCell: UICollectionViewCell {
 		button.frame.size = frame.size
 		button.setTitleColor(.white, for: [])
 		button.titleLabel?.font = .aicNumberPadFont
+        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
 
 		setButtonNormalState()
 

--- a/aic/aic/ViewControllers+Views/Sections/AudioGuide/AudioGuideNavigationController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/AudioGuide/AudioGuideNavigationController.swift
@@ -218,6 +218,8 @@ extension AudioGuideNavigationController: UICollectionViewDataSource {
 			cell.button.accessibilityLabel = "Delete"
 		case "GO":
 			cell.button.setTitle("number_pad_go_action".localized(using: "Audio"), for: .normal)
+                cell.button.titleLabel?.adjustsFontSizeToFitWidth = true
+                cell.button.titleLabel?.minimumScaleFactor = 0.5
 		default:
 			cell.button.setTitle(titleLabel, for: .normal)
 		}


### PR DESCRIPTION
This allows the text of the button (all buttons to be exact) to shrink down the font size in order to prevent truncation. It also adds a bit of horizontal padding to make sure the text doesn't overlap the outer path of the button.

| Truncated | Shrunk |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-12-06 at 22 19 46](https://github.com/user-attachments/assets/21b1fbfc-81fe-48f5-aaf9-48a4811627f0) | ![Simulator Screenshot - iPhone 16 Pro - 2024-12-30 at 16 31 36](https://github.com/user-attachments/assets/fb6a5ee8-12c3-48bf-a62d-ae80e29ec773) | 
