### PR TITLE
List exhibitions in the same order as the website

### DIFF
--- a/aic/aic/Data/AppDataManager.swift
+++ b/aic/aic/Data/AppDataManager.swift
@@ -249,9 +249,9 @@ final class AppDataManager {
 				"gallery_id",
 				"web_url",
 				"aic_start_at",
-				"aic_end_at"
+				"aic_end_at",
+                "position"
 			],
-			"sort": ["aic_start_at", "aic_end_at"],
 			"query": [
 				"bool": [
 					"must": [
@@ -261,15 +261,8 @@ final class AppDataManager {
 							]
 						],
 						[
-							"range": [
-								"aic_end_at": ["gte": "now"]
-							]
-						]
-					],
-					"must_not": [
-						[
 							"term": [
-								"status": "Closed"
+								"is_featured": true
 							]
 						]
 					]
@@ -282,7 +275,7 @@ final class AppDataManager {
 			.responseData { response in
 				switch response.result {
 				case .success(let value):
-					self.exhibitions = self.dataParser.parse(exhibitionsData: value)
+                        self.exhibitions = self.dataParser.parse(exhibitionsData: value).sorted(by: { $0.position < $1.position })
 
 				case .failure(let error):
 					debugPrint(error)

--- a/aic/aic/Data/AppDataParser.swift
+++ b/aic/aic/Data/AppDataParser.swift
@@ -1072,6 +1072,7 @@ final class AppDataParser {
             let id = try getInt(fromJSON: exhibitionJSON, forKey: "id")
             let title = try getString(fromJSON: exhibitionJSON, forKey: "title")
             let description = try getString(fromJSON: exhibitionJSON, forKey: "short_description", optional: true)
+            let position = try getInt(fromJSON: exhibitionJSON, forKey: "position")
 
             // Image
             var imageURL: URL?
@@ -1091,7 +1092,7 @@ final class AppDataParser {
 
             // Get date exibition ends
             let startDateString = try getString(fromJSON: exhibitionJSON, forKey: "aic_start_at")
-            let endDateString = try getString(fromJSON: exhibitionJSON, forKey: "aic_end_at")
+            let endDateString = try getString(fromJSON: exhibitionJSON, forKey: "aic_end_at", optional: true)
 
             let dateFormatter = DateFormatter()
             dateFormatter.locale = Locale(identifier: "en_US")
@@ -1104,11 +1105,19 @@ final class AppDataParser {
                     data: exhibitionJSON.description
                 )
             }
-            guard let endDate = dateFormatter.date(from: endDateString) else {
-                throw ParseError.invalidExhibition(
-                    message: ParseError.invalidDateFormat(dateString: endDateString).errorDescription!,
-                    data: exhibitionJSON.description
-                )
+            
+            let endDate: Date?
+            if endDateString != "" {
+                guard let formattedDate = dateFormatter.date(from: endDateString) else {
+                    throw ParseError.invalidExhibition(
+                        message: ParseError.invalidDateFormat(dateString: endDateString).errorDescription!,
+                        data: exhibitionJSON.description
+                    )
+                }
+                
+                endDate = formattedDate
+            } else {
+                endDate = nil
             }
 
             // Return news item
@@ -1120,7 +1129,8 @@ final class AppDataParser {
                 startDate: startDate,
                 endDate: endDate,
                 galleryId: galleryId,
-                location: location
+                location: location,
+                position: position
             )
         } catch ParseError.missingKey(let key) {
             throw ParseError.invalidExhibition(

--- a/aic/aic/Models/AICExhibitionModel.swift
+++ b/aic/aic/Models/AICExhibitionModel.swift
@@ -11,9 +11,10 @@ class AICExhibitionModel: NSObject {
 	let shortDescription: String
 	var imageUrl: URL?
 	let startDate: Date
-	let endDate: Date
+	let endDate: Date?
 	let galleryId: Int?
 	let location: CoordinateWithFloor? // TODO: making this optional, it's not always available in the data
+    let position: Int
 
     init(
         id: Int,
@@ -21,9 +22,10 @@ class AICExhibitionModel: NSObject {
         shortDescription: String,
         imageUrl: URL?,
         startDate: Date,
-        endDate: Date,
+        endDate: Date?,
         galleryId: Int?,
-        location: CoordinateWithFloor?
+        location: CoordinateWithFloor?,
+        position: Int
     ) {
 		self.id = id
 		self.title = title
@@ -33,6 +35,8 @@ class AICExhibitionModel: NSObject {
 		self.endDate = endDate
 		self.galleryId = galleryId
 		self.location = location
+        self.position = position
+        
 		super.init()
 	}
 }

--- a/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ExhibitionContentCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ExhibitionContentCell.swift
@@ -82,7 +82,12 @@ class ExhibitionContentCell: UITableViewCell {
 			} else {
 				galleryTitleLabel.isHidden = true
 			}
-			throughDateLabel.text = Common.Info.throughDateString(endDate: exhibitionModel.endDate)
+            
+            if let endDate = exhibitionModel.endDate {
+                throughDateLabel.text = Common.Info.throughDateString(endDate: endDate)
+            } else {
+                throughDateLabel.text = ""
+            }
 
 			if exhibitionModel.location == nil {
 				showOnMapButton.isHidden = true

--- a/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ExhibitionContentCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/ExhibitionContentCell.swift
@@ -86,7 +86,7 @@ class ExhibitionContentCell: UITableViewCell {
             if let endDate = exhibitionModel.endDate {
                 throughDateLabel.text = Common.Info.throughDateString(endDate: endDate)
             } else {
-                throughDateLabel.text = ""
+                throughDateLabel.text = "Ongoing"
             }
 
 			if exhibitionModel.location == nil {

--- a/aic/aic/ViewControllers+Views/Sections/Home/Home Cells/HomeExhibitionCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Home/Home Cells/HomeExhibitionCell.swift
@@ -39,7 +39,12 @@ class HomeExhibitionCell: UICollectionViewCell {
 			// set up UI
 			exhibitionImageView.kf.setImage(with: exhibitionModel.imageUrl)
 			exhibitionTitleLabel.text = exhibitionModel.title
-			throughDateTextView.attributedText = attributedStringWithLineHeight(text: Common.Info.throughDateString(endDate: exhibitionModel.endDate), font: .aicTextItalicFont, lineHeight: 22)
+            
+            if let endDate = exhibitionModel.endDate {
+                throughDateTextView.attributedText = attributedStringWithLineHeight(text: Common.Info.throughDateString(endDate: endDate), font: .aicTextItalicFont, lineHeight: 22)
+            } else {
+                throughDateTextView.attributedText = "".attributedString
+            }
 
 			// Accessibility
 			self.accessibilityElements = [

--- a/aic/aic/ViewControllers+Views/Sections/Home/Home Cells/HomeExhibitionCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Home/Home Cells/HomeExhibitionCell.swift
@@ -43,7 +43,7 @@ class HomeExhibitionCell: UICollectionViewCell {
             if let endDate = exhibitionModel.endDate {
                 throughDateTextView.attributedText = attributedStringWithLineHeight(text: Common.Info.throughDateString(endDate: endDate), font: .aicTextItalicFont, lineHeight: 22)
             } else {
-                throughDateTextView.attributedText = "".attributedString
+                throughDateTextView.attributedText = "Ongoing".attributedString
             }
 
 			// Accessibility

--- a/aic/aic/ViewControllers+Views/Sections/Home/See All Cells/SeeAllExhibitionCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Home/See All Cells/SeeAllExhibitionCell.swift
@@ -44,11 +44,16 @@ class SeeAllExhibitionCell: UICollectionViewCell {
     private func setupContent(_ model: AICExhibitionModel) {
         exhibitionImageView.kf.setImage(with: model.imageUrl)
         exhibitionTitleLabel.text = model.title
-        throughDateLabel.attributedText = attributedStringWithLineHeight(
-            text: Common.Info.throughDateString(endDate: model.endDate),
-            font: .aicTextItalicFont,
-            lineHeight: 18
-        )
+        
+        if let endDate = model.endDate {
+            throughDateLabel.attributedText = attributedStringWithLineHeight(
+                text: Common.Info.throughDateString(endDate: endDate),
+                font: .aicTextItalicFont,
+                lineHeight: 18
+            )
+        } else {
+            throughDateLabel.attributedText = "".attributedString
+        }
     }
     private func setupAccessibility() {
         self.isAccessibilityElement = true

--- a/aic/aic/ViewControllers+Views/Sections/Home/See All Cells/SeeAllExhibitionCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Home/See All Cells/SeeAllExhibitionCell.swift
@@ -52,7 +52,7 @@ class SeeAllExhibitionCell: UICollectionViewCell {
                 lineHeight: 18
             )
         } else {
-            throughDateLabel.attributedText = "".attributedString
+            throughDateLabel.attributedText = "Ongoing".attributedString
         }
     }
     private func setupAccessibility() {


### PR DESCRIPTION
This PR makes a couple of small changes in the API call to retrieve current exhibitions:

1. It no longer provides an explicit `sort` parameter, and instead includes the `position` field, which is ultimately used to sort within the app.
2. It removes the requirement that the exhibition have an `aic_end_at` value greater than now, so that exhibitions with a null value will still be returned.
3. Instead of requiring the `status` to not be equal to `Closed`, it instead requires `is_featured` to be true.

@nikhiltri I tried to match the logic used on the website as best I could tell, but let me know if I overlooked or mis-used anything.