### PR TITLE
Fix exhibitions not showing in search results

### DIFF
--- a/aic/aic/Data/SearchDataManager.swift
+++ b/aic/aic/Data/SearchDataManager.swift
@@ -112,7 +112,8 @@ final class SearchDataManager: NSObject {
 				"gallery_id",
 				"web_url",
 				"aic_start_at",
-				"aic_end_at"
+				"aic_end_at",
+                "position"
 			],
 			"q": searchText,
 			"query": [


### PR DESCRIPTION
The app was recently updated to retrieve and use the `position` field to sort exhibitions. This was added to the call to download the data, but was not added to the call used to search for exhibitions. Because this field was missing from the response objects, they failed to decode and were not being shown.

The search query has been updated to include the `position` field in the request, and I also double checked to make sure there weren't any other requests that needed to be updated.