### PR TITLE
Insert two newlines after and ending paragraph tags.

### DIFF
--- a/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/EventContentCell.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Content Card/Table View Cells/EventContentCell.swift
@@ -85,7 +85,7 @@ class EventContentCell: UITableViewCell {
 			let allStyle = Style.font(.aicTextFont).baselineOffset(22.0 - Float(UIFont.aicTitleFont.pointSize)).paragraphStyle(paragraphStyle)
 
 			let eventDescription = eventModel.longDescription
-				.replacingOccurrences(of: "</p>", with: "</p>\n")
+				.replacingOccurrences(of: "</p>", with: "</p>\n\n")
 				.replacingOccurrences(of: "<li>", with: "\n<li>•\t")
 
 			let descriptionAttributedString = eventDescription


### PR DESCRIPTION
The app is currently already inserting a single newline space, but that is not enough to provide any vertical spacing between the text. It's quite possible this was achieving the desired visual result before on a previous iOS version, and the implementation details have just changed over time.