### PR TITLE
Museum hours localization

### DIFF
--- a/aic/aic/Localization/en.lproj/Info.strings
+++ b/aic/aic/Localization/en.lproj/Info.strings
@@ -40,3 +40,5 @@
 "info_designed_by" = "Designed by Potion";
 
 "info_member_log_in_header" = "Already a Member?";
+
+"info_museum_hours" = "Learn about our hours and visiting policies at artic.edu/visit";

--- a/aic/aic/Localization/es.lproj/Info.strings
+++ b/aic/aic/Localization/es.lproj/Info.strings
@@ -40,3 +40,5 @@
 "info_designed_by" = "Diseñado por Potion";
 
 "info_member_log_in_header" = "¿Ya es miembro?";
+
+"info_museum_hours" = "Aprenda más sobre nuestras horas de operación y políticas para visitantes en artic.edu/visit";

--- a/aic/aic/Localization/fr.lproj/Info.strings
+++ b/aic/aic/Localization/fr.lproj/Info.strings
@@ -40,3 +40,5 @@
 "info_designed_by" = "Conçu par Potion";
 
 "info_member_log_in_header" = "Déjà membre ?";
+
+"info_museum_hours" = "Apprenez nos heures et politiques de visiteur à artic.edu/visit";

--- a/aic/aic/Localization/ko.lproj/Info.strings
+++ b/aic/aic/Localization/ko.lproj/Info.strings
@@ -40,3 +40,5 @@
 "info_designed_by" = "디자인";
 
 "info_member_log_in_header" = "이미 회원이십니까?";
+
+"info_museum_hours" = "저희 운영 시간과 관람 정보에 대해 artic.edu/visit 에서 확인하세요";

--- a/aic/aic/Localization/zh-Hans.lproj/Info.strings
+++ b/aic/aic/Localization/zh-Hans.lproj/Info.strings
@@ -40,3 +40,5 @@
 "info_designed_by" = "设计人员 Potion";
 
 "info_member_log_in_header" = "已经是会员？";
+
+"info_museum_hours" = "了解更多关于我们的营业时间和参观规定, 请访问 artic.edu/visit";

--- a/aic/aic/ViewControllers+Views/Sections/Info/MuseumInfoViewController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Info/MuseumInfoViewController.swift
@@ -66,6 +66,11 @@ class MuseumInfoViewController: UIViewController {
 		pageView.titleLabel.text = "info_museum_info_action".localized(using: "Info")
 
 		var text: String = AppDataManager.sharedInstance.app.generalInfo.museumHours
+        // If the API response is empty, fallback to a local translation.
+        if text.isEmpty {
+            text = "info_museum_hours".localized(using: "Info")
+        }
+        
 		text += "\n\n" + Common.Info.museumInformationAddress
 		text += "\n\n" + Common.Info.museumInformationPhoneNumber
 		pageView.textView.text = text


### PR DESCRIPTION
The app still attempts to use the string that is retrieved from the API as the primary translation. In the case where that is empty, the app will now fall back to using translations included in the app bundle.