### PR TITLE
Update Events to use the new `title_display` field

### DIFF
--- a/aic/aic/Data/AppDataManager.swift
+++ b/aic/aic/Data/AppDataManager.swift
@@ -300,6 +300,7 @@ final class AppDataManager {
 			"fields": [
 				"id",
 				"title",
+                "title_display",
 				"description",
 				"short_description",
 				"image_url",

--- a/aic/aic/Data/AppDataParser.swift
+++ b/aic/aic/Data/AppDataParser.swift
@@ -1173,7 +1173,7 @@ final class AppDataParser {
 	func parse(eventJson: JSON) throws -> AICEventModel {
         do {
             let eventId = try getString(fromJSON: eventJson, forKey: "id")
-            let title = try getString(fromJSON: eventJson, forKey: "title")
+            let title = try getString(fromJSON: eventJson, forKey: "title_display")
             let longDescription = try getString(fromJSON: eventJson, forKey: "description")
             let shortDescription = try getString(fromJSON: eventJson, forKey: "short_description", optional: true)
             let imageUrl: URL = try getURL(fromJSON: eventJson, forKey: "image_url")!

--- a/aic/aic/Data/AppDataParser.swift
+++ b/aic/aic/Data/AppDataParser.swift
@@ -1206,7 +1206,7 @@ final class AppDataParser {
             // Return news item
             return AICEventModel(
                 eventId: eventId,
-                title: title.stringByDecodingHTMLEntities,
+                title: title.removeHTMLTags() ?? title,
                 shortDescription: shortDescription.stringByDecodingHTMLEntities,
                 longDescription: longDescription.stringByDecodingHTMLEntities,
                 imageUrl: imageUrl,

--- a/aic/aic/Shared/Extensions/String+AIC.swift
+++ b/aic/aic/Shared/Extensions/String+AIC.swift
@@ -310,6 +310,18 @@ extension String {
 	var stringByDecodingHTMLEntities: String {
 		return decodeHTMLEntities().decodedString
 	}
+    
+    
+    /// Create a version of the string with all HTML tags removed.
+    /// - Returns: The text of the string, without any of the HTML tags (or their content).
+    func removeHTMLTags() -> String? {
+        guard let data = self.data(using: String.Encoding.utf8) else { return nil }
+    
+        let convertedString = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue], documentAttributes: nil)
+        
+        return convertedString?.string
+    }
 
 	/// Returns a tuple containing the string made by relpacing in the
 	/// `String` all HTML character entity references with the corresponding


### PR DESCRIPTION
Use the new `title_display` field so that Event titles are more consistent with what is shown on the web.

This also includes a small helper to strip out any HTML tags from a String, since the app just displays the titles as a plain text field.