### PR TITLE
Provide a default value for the `app` property.

### DIFF
--- a/aic/aic/Data/AppDataManager.swift
+++ b/aic/aic/Data/AppDataManager.swift
@@ -16,7 +16,7 @@ final class AppDataManager {
 	static let sharedInstance = AppDataManager()
 
 	weak var delegate: AppDataManagerDelegate?
-	private(set) var app: AICAppDataModel! = nil
+    private(set) var app = AICAppDataModel(generalInfo: .init(translations: [:]), map: .init(floors: []))
 	private(set) var exhibitions = [AICExhibitionModel]()
 	private(set) var events = [AICEventModel]()
 


### PR DESCRIPTION
This should be safer than an explicitly unwrapped optional that is set to nil.