### PR TITLE
Use the `title` field as a fallback when `title_display` is null.

### DIFF
--- a/aic/aic/Data/AppDataParser.swift
+++ b/aic/aic/Data/AppDataParser.swift
@@ -1173,7 +1173,8 @@ final class AppDataParser {
 	func parse(eventJson: JSON) throws -> AICEventModel {
         do {
             let eventId = try getString(fromJSON: eventJson, forKey: "id")
-            let title = try getString(fromJSON: eventJson, forKey: "title_display")
+            let displayTitle = try getString(fromJSON: eventJson, forKey: "title_display", optional: true)
+            let title = try getString(fromJSON: eventJson, forKey: "title")
             let longDescription = try getString(fromJSON: eventJson, forKey: "description")
             let shortDescription = try getString(fromJSON: eventJson, forKey: "short_description", optional: true)
             let imageUrl: URL = try getURL(fromJSON: eventJson, forKey: "image_url")!
@@ -1206,7 +1207,7 @@ final class AppDataParser {
             // Return news item
             return AICEventModel(
                 eventId: eventId,
-                title: title.removeHTMLTags() ?? title,
+                title: displayTitle.removeHTMLTags() ?? title,
                 shortDescription: shortDescription.stringByDecodingHTMLEntities,
                 longDescription: longDescription.stringByDecodingHTMLEntities,
                 imageUrl: imageUrl,

--- a/aic/aic/Shared/Extensions/String+AIC.swift
+++ b/aic/aic/Shared/Extensions/String+AIC.swift
@@ -315,6 +315,7 @@ extension String {
     /// Create a version of the string with all HTML tags removed.
     /// - Returns: The text of the string, without any of the HTML tags (or their content).
     func removeHTMLTags() -> String? {
+        guard self.isEmpty == false else { return nil }
         guard let data = self.data(using: String.Encoding.utf8) else { return nil }
     
         let convertedString = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html,


### PR DESCRIPTION
To prevent an Event from failing to parse (and thus not be shown in the app) when the `title_display` field is NULL, the response value is now marked as optional, and the `title` field will be used as a fallback.