### PR TITLE
Member card crashes

### DIFF
--- a/aic/aic.xcodeproj/project.pbxproj
+++ b/aic/aic.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		306E6E4F2469CA4D00B17CA8 /* Base.strings in Resources */ = {isa = PBXBuildFile; fileRef = 306E6E1B2469CA4C00B17CA8 /* Base.strings */; };
 		306E6E502469CA4D00B17CA8 /* LocationUI.strings in Resources */ = {isa = PBXBuildFile; fileRef = 306E6E1D2469CA4C00B17CA8 /* LocationUI.strings */; };
 		3099149B23A8385E00E32ACE /* InfoBuyTicketsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3099149A23A8385E00E32ACE /* InfoBuyTicketsView.swift */; };
+		8DB858F32D8B6E11009E9B1B /* Array+AIC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DB858F22D8B6E11009E9B1B /* Array+AIC.swift */; };
 		E20B1C0829D525A90095E59C /* MapPointOfInterestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20B1C0729D525A90095E59C /* MapPointOfInterestType.swift */; };
 		E218869429C0036F00803FF9 /* UIApplication+KeyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E218869329C0036F00803FF9 /* UIApplication+KeyWindow.swift */; };
 		E21D01B12BFD0C6100E75C53 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E21D01B02BFD0C6100E75C53 /* GoogleService-Info.plist */; };
@@ -421,6 +422,7 @@
 		306E6E452469CA4C00B17CA8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Base.strings; sourceTree = "<group>"; };
 		306E6E462469CA4C00B17CA8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LocationUI.strings; sourceTree = "<group>"; };
 		3099149A23A8385E00E32ACE /* InfoBuyTicketsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBuyTicketsView.swift; sourceTree = "<group>"; };
+		8DB858F22D8B6E11009E9B1B /* Array+AIC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+AIC.swift"; sourceTree = "<group>"; };
 		E20B1C0729D525A90095E59C /* MapPointOfInterestType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPointOfInterestType.swift; sourceTree = "<group>"; };
 		E218869329C0036F00803FF9 /* UIApplication+KeyWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+KeyWindow.swift"; sourceTree = "<group>"; };
 		E21D01B02BFD0C6100E75C53 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "aic/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -872,6 +874,7 @@
 		E218869529C0037300803FF9 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				8DB858F22D8B6E11009E9B1B /* Array+AIC.swift */,
 				E421783B1CC6E1F300815B41 /* String+AIC.swift */,
 				E218869329C0036F00803FF9 /* UIApplication+KeyWindow.swift */,
 				E4D790E11C90AD200033EE0A /* UIColor+AIC.swift */,
@@ -1543,6 +1546,7 @@
 				E2C348672C2345E0007392BB /* CrashlyticsManager.swift in Sources */,
 				2975A057203F61250014017C /* MapExhibitionAnnotationView.swift in Sources */,
 				E4D159351CBAE3E900536B4D /* AICTourModel.swift in Sources */,
+				8DB858F32D8B6E11009E9B1B /* Array+AIC.swift in Sources */,
 				29824BCB200D867C003B6DB5 /* ContentCardNavigationController.swift in Sources */,
 				29F12BC2204F4C37009C1A47 /* MapTourStartContentView.swift in Sources */,
 				2994891F1FA3849C00943197 /* AICGeneralInfoModel.swift in Sources */,

--- a/aic/aic.xcodeproj/project.pbxproj
+++ b/aic/aic.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		306E6E4F2469CA4D00B17CA8 /* Base.strings in Resources */ = {isa = PBXBuildFile; fileRef = 306E6E1B2469CA4C00B17CA8 /* Base.strings */; };
 		306E6E502469CA4D00B17CA8 /* LocationUI.strings in Resources */ = {isa = PBXBuildFile; fileRef = 306E6E1D2469CA4C00B17CA8 /* LocationUI.strings */; };
 		3099149B23A8385E00E32ACE /* InfoBuyTicketsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3099149A23A8385E00E32ACE /* InfoBuyTicketsView.swift */; };
+		8D919A752DD9363800FED627 /* GeneralCrashlyticsReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D919A742DD9363800FED627 /* GeneralCrashlyticsReport.swift */; };
 		8DB858F32D8B6E11009E9B1B /* Array+AIC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DB858F22D8B6E11009E9B1B /* Array+AIC.swift */; };
 		E20B1C0829D525A90095E59C /* MapPointOfInterestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20B1C0729D525A90095E59C /* MapPointOfInterestType.swift */; };
 		E218869429C0036F00803FF9 /* UIApplication+KeyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E218869329C0036F00803FF9 /* UIApplication+KeyWindow.swift */; };
@@ -422,6 +423,7 @@
 		306E6E452469CA4C00B17CA8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Base.strings; sourceTree = "<group>"; };
 		306E6E462469CA4C00B17CA8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LocationUI.strings; sourceTree = "<group>"; };
 		3099149A23A8385E00E32ACE /* InfoBuyTicketsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBuyTicketsView.swift; sourceTree = "<group>"; };
+		8D919A742DD9363800FED627 /* GeneralCrashlyticsReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCrashlyticsReport.swift; sourceTree = "<group>"; };
 		8DB858F22D8B6E11009E9B1B /* Array+AIC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+AIC.swift"; sourceTree = "<group>"; };
 		E20B1C0729D525A90095E59C /* MapPointOfInterestType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPointOfInterestType.swift; sourceTree = "<group>"; };
 		E218869329C0036F00803FF9 /* UIApplication+KeyWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+KeyWindow.swift"; sourceTree = "<group>"; };
@@ -913,6 +915,7 @@
 				E2C3485D2C2345E0007392BB /* CrashlyticsReport.swift */,
 				E2C3485E2C2345E0007392BB /* CrashlyticsService.swift */,
 				E2C3485F2C2345E0007392BB /* DataParserCrashlyticsReport.swift */,
+				8D919A742DD9363800FED627 /* GeneralCrashlyticsReport.swift */,
 			);
 			path = Crashlytics;
 			sourceTree = "<group>";
@@ -1485,6 +1488,7 @@
 				E433BACF1CFDD64A0086F2ED /* AppDelegate.swift in Sources */,
 				E4F7AF951CFB64DE00524F87 /* AICMapModel.swift in Sources */,
 				E4E108DC1C98A89A00385842 /* AICAudioFileModel.swift in Sources */,
+				8D919A752DD9363800FED627 /* GeneralCrashlyticsReport.swift in Sources */,
 				E4F518FB1D2586B0004BFB44 /* AICImageView.swift in Sources */,
 				290B6CCB208510DE0022F6AE /* UIFont+FontNames.swift in Sources */,
 				E2C72F0829C3EFA30021F1EC /* UIViewController+ChildTransition.swift in Sources */,

--- a/aic/aic/Analytics/Crashlytics/GeneralCrashlyticsReport.swift
+++ b/aic/aic/Analytics/Crashlytics/GeneralCrashlyticsReport.swift
@@ -11,8 +11,6 @@ import Foundation
 struct GeneralCrashlyticsReport: CrashlyticsReport {
     var error: any Error
     var log: String
-    
-    
 }
 
 enum GeneralError: Error {

--- a/aic/aic/Analytics/Crashlytics/GeneralCrashlyticsReport.swift
+++ b/aic/aic/Analytics/Crashlytics/GeneralCrashlyticsReport.swift
@@ -1,0 +1,20 @@
+//
+//  GeneralCrashlyticsReport.swift
+//  aic
+//
+//  Created by David Bireta on 5/17/25.
+//  Copyright © 2025 Art Institute of Chicago. All rights reserved.
+//
+
+import Foundation
+
+struct GeneralCrashlyticsReport: CrashlyticsReport {
+    var error: any Error
+    var log: String
+    
+    
+}
+
+enum GeneralError: Error {
+    case general
+}

--- a/aic/aic/Data/MemberDataManager.swift
+++ b/aic/aic/Data/MemberDataManager.swift
@@ -132,7 +132,7 @@ class MemberDataManager {
 					var isReciprocal = false
 					var isLifeMembership = false
 
-					switch memberLevel! {
+					switch memberLevel {
 					case "Life Membership":
 						memberLevel = "Life Member"
 						isLifeMembership = true
@@ -207,8 +207,9 @@ class MemberDataManager {
 
 		var firstName: String = ""
 		if currentMemberNameIndex < memberCard.memberNames.count {
-			let fullName: String = memberCard.memberNames[currentMemberNameIndex]
-			firstName = String(describing: fullName.split(separator: " ").first!)
+            if let fullName: String = memberCard.memberNames[safeIndex: currentMemberNameIndex] {
+                firstName = String(fullName.split(separator: " ").first ?? "")
+            }
 		}
 
 		// Store

--- a/aic/aic/Shared/Extensions/Array+AIC.swift
+++ b/aic/aic/Shared/Extensions/Array+AIC.swift
@@ -1,0 +1,17 @@
+//
+//  Array+AIC.swift
+//  aic
+//
+//  Created by David Bireta on 3/15/25.
+//  Copyright © 2025 Art Institute of Chicago. All rights reserved.
+//
+
+import Foundation
+
+extension Array {
+    public subscript(safeIndex index: Int) -> Element? {
+        guard index >= 0, index < endIndex else { return nil }
+
+        return self[index]
+    }
+}

--- a/aic/aic/ViewControllers+Views/Sections/Info/MemberCardViewController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Info/MemberCardViewController.swift
@@ -167,7 +167,8 @@ class MemberCardViewController: UIViewController {
 	@objc private func switchCardholderButtonPressed(button: UIButton) {
 		if let memberCard = MemberDataManager.sharedInstance.currentMemberCard {
 			MemberDataManager.sharedInstance.currentMemberNameIndex = MemberDataManager.sharedInstance.currentMemberNameIndex < memberCard.memberNames.count - 1 ? MemberDataManager.sharedInstance.currentMemberNameIndex + 1 : 0
-			cardView.memberNameLabel.text = memberCard.memberNames[MemberDataManager.sharedInstance.currentMemberNameIndex]
+            
+            cardView.memberNameLabel.text = memberCard.memberNames[MemberDataManager.sharedInstance.currentMemberNameIndex]
 
 			MemberDataManager.sharedInstance.saveCurrentMember()
 		}

--- a/aic/aic/ViewControllers+Views/Sections/Info/Views/MemberCardView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Info/Views/MemberCardView.swift
@@ -17,6 +17,15 @@ class MemberCardView: UIView {
 	let switchCardholderButton: AICButton = AICButton(isSmall: false)
 
 	private let barcodeWidth: CGFloat = min(UIScreen.main.bounds.width - 10, 365)
+    
+    private let crashlyticsManager = CrashlyticsManager(
+        service: FirebaseCrashlyticsService(),
+        properties: [
+            AnalyticsProperty.make(by: .appLanguage),
+            AnalyticsProperty.make(by: .deviceLanguage),
+            AnalyticsProperty.make(by: .membership)
+        ]
+    )
 
 	init() {
 		super.init(frame: CGRect.zero)
@@ -83,6 +92,9 @@ class MemberCardView: UIView {
 
 	func setContent(memberCard: AICMemberCardModel, memberNameIndex: Int) {
         guard let memberNames = memberCard.memberNames[safeIndex: memberNameIndex] else {
+            let report = GeneralCrashlyticsReport(error: GeneralError.general, log: "Unable to get member index \(memberNameIndex) from \(memberCard.memberNames.count) total indexes")
+            crashlyticsManager.record(report)
+            
             return
         }
         

--- a/aic/aic/ViewControllers+Views/Sections/Info/Views/MemberCardView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Info/Views/MemberCardView.swift
@@ -82,7 +82,11 @@ class MemberCardView: UIView {
 	}
 
 	func setContent(memberCard: AICMemberCardModel, memberNameIndex: Int) {
-		memberNameLabel.text = memberCard.memberNames[memberNameIndex]
+        guard let memberNames = memberCard.memberNames[safeIndex: memberNameIndex] else {
+            return
+        }
+        
+		memberNameLabel.text = memberNames
 
 		// Expiration Date
 		let dateFormatter = DateFormatter()


### PR DESCRIPTION
This adds a new extension to the `Array` type which will return nil, instead of crashing, when an out-of-bounds index is accessed. There is also an additional log message sent to crashlytics if this happens.