### PR TITLE
Fix map annotations disappearing when selected

### DIFF
--- a/aic/aic/Shared/Common.swift
+++ b/aic/aic/Shared/Common.swift
@@ -238,7 +238,7 @@ extension Common {
             case zoomFarLimit = 1200
             case zoomLimit = 340
             case zoomDefault = 300
-            case zoomMedium = 150
+            case zoomMedium = 175
             case zoomDetail = 50
             case zoomMax = 25
 

--- a/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
@@ -200,6 +200,8 @@ class MapView: MKMapView {
 		// Altitude
 		previousAltitude = currentAltitude
 		currentAltitude = camera.centerCoordinateDistance
+        
+        guard currentAltitude != previousAltitude else { return }
 
 		// Zoom Level
 		previousZoomLevel = currentZoomLevel

--- a/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
@@ -201,7 +201,7 @@ class MapView: MKMapView {
 		previousAltitude = currentAltitude
 		currentAltitude = camera.centerCoordinateDistance
         
-        guard currentAltitude != previousAltitude else { return }
+        guard abs(currentAltitude - previousAltitude) > 5 else { return }
 
 		// Zoom Level
 		previousZoomLevel = currentZoomLevel


### PR DESCRIPTION
On certain iPhone models, the map annotation would disappear after it was selected. This seems to be caused by the map zooming out slightly (something being done automatically by MapKit), exceeding the zoom threshold where annotations would be shown on the map.

This change slightly modifies the zoom level so that the annotation will still be visible.