### PR TITLE
Use the numberpad for both member card entry textfields.

### DIFF
--- a/aic/aic/ViewControllers+Views/Sections/Info/Views/MemberLoginView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Info/Views/MemberLoginView.swift
@@ -46,7 +46,8 @@ class MemberLoginView: UIView {
 		memberZipCodeTextField.font = .aicMemberCardLoginFieldFont
 		memberZipCodeTextField.leftViewMode = .always
 		memberZipCodeTextField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 40))
-		memberZipCodeTextField.keyboardType = .numbersAndPunctuation
+		memberZipCodeTextField.keyboardType = .numberPad
+        memberZipCodeTextField.textContentType = .postalCode
 
 		loginButton.setColorMode(colorMode: AICButton.orangeMode)
 		loginButton.setTitle("Sign In", for: .normal)


### PR DESCRIPTION
The member card ID was already set to use the numbered, so this just updates the Zip Code field. It also provides some context for the zip code textField so that it is possible for the OS to provide a suggestion.