### PR TITLE
Add a variant that allows dynamic sizing based on text content.

### DIFF
--- a/aic/aic/Shared/AICButton.swift
+++ b/aic/aic/Shared/AICButton.swift
@@ -48,6 +48,10 @@ class AICButton: UIButton {
 		normal: ColorSet(borderColor: .white, backgroundColor: UIColor(white: 1, alpha: 0), textColor: .white),
 		highlighted: ColorSet(borderColor: .white, backgroundColor: UIColor(white: 216.0 / 255.0, alpha: 0.5), textColor: .white)
 	)
+    
+    enum Size {
+        case small, medium, dynamic
+    }
 
 	private let insets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
 	private let mediumSize: CGSize = CGSize(width: 190, height: 50)
@@ -66,6 +70,21 @@ class AICButton: UIButton {
 			}
 		}
 	}
+    
+    init(withSize size: Size) {
+        super.init(frame: .zero)
+        
+        switch size {
+            case .small:
+                self.autoSetDimensions(to: CGSize(width: smallSize.width - (borderWidth), height: smallSize.height - (borderWidth)))
+            case .medium:
+                self.autoSetDimensions(to: CGSize(width: mediumSize.width - (borderWidth), height: mediumSize.height - (borderWidth)))
+            case .dynamic:
+                break
+        }
+        
+        setup()
+    }
 
 	init(isSmall: Bool) {
 		super.init(frame: CGRect.zero)
@@ -74,7 +93,7 @@ class AICButton: UIButton {
 		self.autoSetDimensions(to: CGSize(width: frameSize.width - (borderWidth), height: frameSize.height - (borderWidth)))
 		setup()
 	}
-
+    
 	required init?(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 	}

--- a/aic/aic/ViewControllers+Views/Sections/Map/Map Card/Views/MapTourStartContentView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/Map Card/Views/MapTourStartContentView.swift
@@ -10,7 +10,7 @@ import UIKit
 import Localize_Swift
 
 class MapTourStartContentView: UIView {
-	let audioButton: AICButton = AICButton(isSmall: false)
+    let audioButton: AICButton = AICButton(withSize: AICButton.Size.dynamic)
 
 	private let frameSize: CGSize = CGSize(width: UIScreen.main.bounds.width, height: Common.Layout.cardMinimizedContentHeight - Common.Layout.miniAudioPlayerHeight)
 
@@ -20,6 +20,7 @@ class MapTourStartContentView: UIView {
 		audioButton.setColorMode(colorMode: AICButton.blueMode)
 		audioButton.setIconImage(image: #imageLiteral(resourceName: "buttonPlayIcon"))
 		audioButton.setTitle("tour_play_tour_introduction_action".localized(using: "Base"), for: .normal)
+        audioButton.contentEdgeInsets = .init(top: 10, left: 20, bottom: 10, right: 10)
 
 		self.addSubview(audioButton)
 


### PR DESCRIPTION
This fixes an issue where the `Play Tour Introduction` button on the map was truncating the Spanish text.