### PR TITLE
Map improvements

### DIFF
--- a/aic/aic/Application/AppDelegate.swift
+++ b/aic/aic/Application/AppDelegate.swift
@@ -19,7 +19,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        #if !DEBUG
         setupAnalytics()
+        #endif
+        
 		// Set initial state for location tracking
         let locationManager = CLLocationManager()
 		Common.Location.hasLoggedOnsite = false

--- a/aic/aic/Shared/Common.swift
+++ b/aic/aic/Shared/Common.swift
@@ -235,8 +235,8 @@ extension Common {
         static let defaultLocation = CLLocationCoordinate2D(latitude: 41.8796, longitude: -87.623533)
 
         enum ZoomLevelAltitude: Double, CaseIterable {
-            case zoomFarLimit = 1200
-            case zoomLimit = 340
+            case zoomFarLimit = 1501
+            case zoomLimit = 1500
             case zoomDefault = 300
             case zoomMedium = 175
             case zoomDetail = 50

--- a/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
@@ -52,8 +52,11 @@ class MapView: MKMapView {
         
         setup()
         
-        // Set maximum zoom amount (in meters)
-        self.cameraZoomRange = .init(maxCenterCoordinateDistance: Common.Map.ZoomLevelAltitude.zoomLimit.rawValue)
+        // Set maximum zoom amount
+        self.cameraZoomRange = CameraZoomRange(maxCenterCoordinateDistance: Common.Map.ZoomLevelAltitude.zoomLimit.rawValue)
+        
+        // Set maximum panning bounds
+        self.cameraBoundary = CameraBoundary(coordinateRegion: MKCoordinateRegion(center: Common.Map.defaultLocation, latitudinalMeters: 500, longitudinalMeters: 500))
 	}
 
 	required init?(coder aDecoder: NSCoder) {

--- a/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
@@ -162,7 +162,7 @@ class MapView: MKMapView {
         if let pitch {
             newCamera.pitch = pitch
         } else {
-            newCamera.pitch = perspectivePitch
+            newCamera.pitch = topDownPitch
         }
 
         setCamera(newCamera, animated: animated)
@@ -230,7 +230,7 @@ private extension MapView {
         pointOfInterestFilter = .excludingAll
         
         isZoomEnabled = true
-        isPitchEnabled = true
+        isPitchEnabled = false
         showsCompass = false
         showsScale = false
         showsTraffic = false

--- a/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
@@ -49,7 +49,11 @@ class MapView: MKMapView {
             width: UIScreen.main.bounds.width,
             height: UIScreen.main.bounds.height
         )
+        
         setup()
+        
+        // Set maximum zoom amount (in meters)
+        self.cameraZoomRange = .init(maxCenterCoordinateDistance: Common.Map.ZoomLevelAltitude.zoomLimit.rawValue)
 	}
 
 	required init?(coder aDecoder: NSCoder) {

--- a/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapView.swift
@@ -172,28 +172,6 @@ class MapView: MKMapView {
         debugPrint("MapView.\(newCamera.debugDescription)")
     }
 
-	func keepMapInView(zoomLimit: Double) {
-		// Check altitude
-		if currentAltitude > zoomLimit {
-            showFullMap(centerCoordinateDistance: Common.Map.ZoomLevelAltitude.zoomDefault.rawValue + 5)
-            debugPrint("MapView.keepMapInView zoomLimit: \(zoomLimit)")
-		} else {
-			// Make sure our floorplan is on-screen
-			if let floorplanOverlay = floorplanOverlay {
-				let buildingRect = floorplanOverlay.boundingMapRect
-				let cameraCenter = MKMapPoint(camera.centerCoordinate)
-				let distanceFromBuildingCenter = cameraCenter.distance(to: buildingRect.getCenter())
-
-				if distanceFromBuildingCenter > Common.Location.minDistanceFromMuseumForLocation {
-                    zoomIn(onCenterCoordinate: floorplanOverlay.coordinate,
-                           centerCoordinateDistance: camera.centerCoordinateDistance,
-                           heading: nil,
-                           pitch: camera.pitch)
-				}
-			}
-		}
-	}
-
 	// Find the altitude based on our start value and the current map visible to bounds ratio
 	func calculateStartingHeight() {
 		// Set the starting height for checking altitude while zooming

--- a/aic/aic/ViewControllers+Views/Sections/Map/MapViewController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapViewController.swift
@@ -938,25 +938,6 @@ extension MapViewController: MKMapViewDelegate {
 			}
 		}
 	}
-
-    /**
-     When the map region changes update view properties
-     */
-    func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
-        self.mapView.calculateCurrentAltitudeAndZoomLevel()
-
-        // Keep map in view
-        if !floorSelectorViewController.userHeadingIsEnabled() {
-            self.mapView.keepMapInView(zoomLimit: zoomLimitValue)
-        }
-    }
-
-    func mapViewWillStartRenderingMap(_ mapView: MKMapView) {
-    }
-
-    func mapViewDidFinishLoadingMap(_ mapView: MKMapView) {
-    }
-
 }
 
 // MARK: Floor Selector Delegate Methods

--- a/aic/aic/ViewControllers+Views/Sections/Map/MapViewController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapViewController.swift
@@ -105,7 +105,7 @@ final class MapViewController: UIViewController {
                      centerCoordinateDistance: Common.Map.ZoomLevelAltitude.zoomDetail.rawValue - 10.0,
                      withAnimation: true,
                      heading: mapView.camera.heading,
-                     pitch: mapView.perspectivePitch)
+                     pitch: mapView.topDownPitch)
 		}
 	}
 
@@ -254,7 +254,7 @@ final class MapViewController: UIViewController {
 		// Show all annotations messes with the pitch + heading,
 		// so reset our pitch + heading to preferred defaults
 		mapView.camera.heading = mapView.defaultHeading
-		mapView.camera.pitch = mapView.perspectivePitch
+		mapView.camera.pitch = mapView.topDownPitch
 		if mapView.camera.centerCoordinateDistance <= Common.Map.ZoomLevelAltitude.zoomDetail.rawValue {
 			mapView.camera.centerCoordinateDistance = Common.Map.ZoomLevelAltitude.zoomMedium.rawValue
 		} else if mapView.camera.centerCoordinateDistance > zoomLimitValue {
@@ -340,7 +340,7 @@ final class MapViewController: UIViewController {
                                    centerCoordinateDistance: Common.Map.ZoomLevelAltitude.zoomDetail.rawValue,
                                    withAnimation: true,
                                    heading: mapView.camera.heading,
-                                   pitch: mapView.perspectivePitch)
+                                   pitch: mapView.topDownPitch)
 
 					// Select the annotation (which eventually updates it's view)
 					mapView.selectAnnotation(annotation, animated: false)
@@ -367,7 +367,7 @@ final class MapViewController: UIViewController {
                          centerCoordinateDistance: Common.Map.ZoomLevelAltitude.zoomMedium.rawValue - 50,
                          withAnimation: true,
                          heading: mapView.camera.heading,
-                         pitch: mapView.perspectivePitch)
+                         pitch: mapView.topDownPitch)
 
 					// Select the annotation (which eventually updates it's view)
 					mapView.selectAnnotation(annotation, animated: true)
@@ -392,7 +392,7 @@ final class MapViewController: UIViewController {
                          centerCoordinateDistance: Common.Map.ZoomLevelAltitude.zoomDefault.rawValue,
                          withAnimation: true,
                          heading: mapView.camera.heading,
-                         pitch: mapView.perspectivePitch)
+                         pitch: mapView.topDownPitch)
 
 					// Select the annotation (which eventually updates it's view)
 					mapView.selectAnnotation(annotation, animated: true)
@@ -1225,7 +1225,7 @@ private extension MapViewController {
         mapView.camera.heading = 0
         mapView.camera.centerCoordinateDistance = Common.Map.ZoomLevelAltitude.zoomLimit.rawValue
         mapView.camera.centerCoordinate = mapModel.floors.first!.overlay.coordinate
-        mapView.camera.pitch = mapView.perspectivePitch
+        mapView.camera.pitch = mapView.topDownPitch
     }
 
     func setupNavigationItemTitle() {

--- a/aic/aic/ViewControllers+Views/Sections/Map/MapViewController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Map/MapViewController.swift
@@ -536,6 +536,7 @@ final class MapViewController: UIViewController {
 			annotations.append(contentsOf: mapModel.floors[currentFloor].amenityAnnotations as [MKAnnotation])
 			annotations.append(contentsOf: mapModel.floors[currentFloor].departmentAnnotations as [MKAnnotation])
 			//			annotations.append(contentsOf: mapModel.floors[currentFloor].farObjectAnnotations as [MKAnnotation])
+                annotations.append(contentsOf: mapModel.floors[currentFloor].galleryAnnotations as [MKAnnotation])
 			break
 
 		case .zoomMedium:
@@ -544,6 +545,7 @@ final class MapViewController: UIViewController {
 			annotations.append(contentsOf: mapModel.floors[currentFloor].amenityAnnotations as [MKAnnotation])
 			annotations.append(contentsOf: mapModel.floors[currentFloor].departmentAnnotations as [MKAnnotation])
 			annotations.append(contentsOf: mapModel.floors[currentFloor].objectAnnotations as [MKAnnotation])
+                annotations.append(contentsOf: mapModel.floors[currentFloor].galleryAnnotations as [MKAnnotation])
 			//			annotations.append(contentsOf: mapModel.floors[currentFloor].farObjectAnnotations as [MKAnnotation])
 			break
 
@@ -554,6 +556,7 @@ final class MapViewController: UIViewController {
 			annotations.append(contentsOf: mapModel.floors[currentFloor].objectAnnotations as [MKAnnotation])
 			break
 		}
+
 		annotations.append(contentsOf: mapModel.imageAnnotations as [MKAnnotation])
 		annotations.append(mapView.userLocation)
 


### PR DESCRIPTION
This attempts to address some of the bigger pain points with the map by:

- Modifying the allowed zoom and panning regions so that the building can be viewed in its entirety.
- Switching to a fixed top-down perspective
- Never attempting to automatically re-center or re-zoom the map (user can still tap the compass to center on their location)
- Always displaying the gallery numbers at all but the highest zoom levels.
