### PR TITLE
Home Screen - Exhibitions

### DIFF
--- a/aic/SwiftUI Views/AICButtonStyle.swift
+++ b/aic/SwiftUI Views/AICButtonStyle.swift
@@ -1,0 +1,31 @@
+//
+//  AICButtonStyle.swift
+//  aic
+//
+//  Created by David Bireta on 4/10/26.
+//  Copyright © 2026 Art Institute of Chicago. All rights reserved.
+//
+
+import SwiftUI
+
+struct AICButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .aicOldFontStyle(.actionButton)
+            .padding()
+            .padding(.horizontal)
+            .foregroundStyle(.white)
+            .background(configuration.isPressed ? Color.infoBackground.opacity(0.3) : Color.infoBackground)
+    }
+}
+
+struct AICTealButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .aicOldFontStyle(.actionButton)
+            .padding()
+            .padding(.horizontal)
+            .foregroundStyle(.white)
+            .background(configuration.isPressed ? Color.teal.opacity(0.3) : Color.teal)
+    }
+}

--- a/aic/SwiftUI Views/BigCard.swift
+++ b/aic/SwiftUI Views/BigCard.swift
@@ -1,0 +1,57 @@
+//
+//  BigCard.swift
+//  aic
+//
+//  Created by David Bireta on 2/18/26.
+//  Copyright © 2026 Art Institute of Chicago. All rights reserved.
+//
+
+import SwiftUI
+
+struct BigCard<OverlayContent: View>: View {
+    let title: String
+    let subtitle: LocalizedStringKey
+    let imageURL: URL?
+    @ViewBuilder let bottomOverlay: OverlayContent?
+    
+    @ScaledMetric private var leading = 22.0
+    
+    init(title: String, subtitle: LocalizedStringKey, imageURL: URL?, bottomOverlay: OverlayContent?) {
+        self.title = title
+        self.subtitle = subtitle
+        self.imageURL = imageURL
+        self.bottomOverlay = bottomOverlay
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Rectangle()
+                .fill(.red)
+                .frame(height: 200)
+                .overlay {
+                    RemoteImage(imageID: title, imageURL: imageURL, height: 200)
+                }
+                .clipped()
+                .overlay(alignment: .bottom) {
+                    if let bottomOverlay {
+                        bottomOverlay
+                            .aicOldFontStyle(.overlay)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .foregroundStyle(.white)
+                            .padding(8)
+                            .background(.black.opacity(0.5))
+                    }
+                }
+
+            Text(title)
+                .aicOldFontStyle(.title)
+                .multilineTextAlignment(.leading)
+            
+            Text(subtitle)
+                .aicOldFontStyle(.subtitle)
+                .requestTightLineHeight(points: leading)
+                .lineLimit(3)
+                .multilineTextAlignment(.leading)
+        }
+    }
+}

--- a/aic/SwiftUI Views/ExhibitionCard.swift
+++ b/aic/SwiftUI Views/ExhibitionCard.swift
@@ -1,0 +1,46 @@
+//
+//  ExhibitionCard.swift
+//  aic
+//
+//  Created by David Bireta on 2/13/26.
+//  Copyright © 2026 Art Institute of Chicago. All rights reserved.
+//
+
+import SwiftUI
+
+struct ExhibitionCard: View {
+    let title: String
+    let shortDescription: String
+    let endDate: Date
+    let imageURL: URL?
+    
+    @ScaledMetric private var leadingAmount = 20.0
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            RemoteImage(imageID: title, imageURL: imageURL, height: 200)
+            
+            Text("Exhibition".uppercased())
+                .fontWeight(.light)
+
+            Text(title)
+                .requestTightLineHeight(points: leadingAmount)
+                .multilineTextAlignment(.leading)
+                .padding(.bottom)
+            
+            Text(endDate.formatted(date: .abbreviated, time: .omitted))
+                .fontWeight(.light)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .background(
+            Rectangle()
+                .fill(.background)
+                .shadow(radius: 3)
+        )
+    }
+}
+
+#Preview {
+    ExhibitionCard(title: "Carroll Dunham: Drawings, 1974–2024", shortDescription: "alkdsfj", endDate: .now, imageURL: nil)
+}

--- a/aic/SwiftUI Views/ExhibitionDetailView.swift
+++ b/aic/SwiftUI Views/ExhibitionDetailView.swift
@@ -1,0 +1,111 @@
+//
+//  ExhibitionDetailView.swift
+//  aic
+//
+//  Created by David Bireta on 2/19/26.
+//  Copyright © 2026 Art Institute of Chicago. All rights reserved.
+//
+
+import SwiftUI
+
+struct ExhibitionDetailView: View {
+    let exhibition: AICExhibitionModel
+    
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var coordinator: HomeNavigationCoordinator
+    @ScaledMetric private var leading = 20.0
+    
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading) {
+                    Text(exhibition.title)
+                        .aicOldFontStyle(.title)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                    
+                    RemoteImage(imageID: exhibition.id.formatted(), imageURL: exhibition.imageUrl, height: 400)
+                    
+                    HStack {
+                        if exhibition.location != nil {
+                            Button {
+                                handleShowOnMap(with: exhibition)
+                            } label: {
+                                Label(.Base.contentShowOnMapAction, image: "buttonMapIcon")
+                            }
+                            .buttonStyle(AICTealButtonStyle())
+                        }
+                        
+                        Button(action: handleBuyTickets) {
+                            Label(.Base.eventBuyTicketsAction, image: "buttonTicketIcon")
+                        }
+                        .buttonStyle(AICTealButtonStyle())
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical)
+                    
+                    Text(LocalizedStringKey(exhibition.shortDescription))
+                        .aicOldFontStyle(.subtitle)
+                        .requestTightLineHeight(points: leading)
+                        .padding([.horizontal, .bottom])
+                    
+                    if let galleryID = exhibition.galleryId, let galleryName = galleryName(for: galleryID) {
+                        Text(galleryName)
+                            .aicOldFontStyle(.subtitle)
+                            .padding([.horizontal, .bottom])
+                    }
+                    
+                    if let endDate = exhibition.endDate {
+                        Text(.Base.contentThroughDate(endDate.formatted(date: .long, time: .omitted)))
+                            .aicOldFontStyle(.subtitle).italic()
+                            .padding(.horizontal)
+                    } else {
+                        // TODO: Missing translation
+                        Text("Ongoing")
+                            .aicOldFontStyle(.subtitle).italic()
+                            .padding(.horizontal)
+                    }
+                }
+            }
+            .scrollIndicators(.hidden)
+            .scrollBounceBehavior(.basedOnSize)
+            .toolbar {
+                ToolbarItem {
+                    if #available(iOS 26.0, *) {
+                        Button(role: .close) {
+                            dismiss()
+                        }
+                    } else {
+                        Button {
+                            dismiss()
+                        } label: {
+                            Image(systemName: "xmark.circle")
+                                .imageScale(.large)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension ExhibitionDetailView {
+    private func galleryName(for id: Int) -> String? {
+        AppDataManager.sharedInstance.getGallery(with: id)?.title
+    }
+    
+    private func handleBuyTickets() {
+        // Log analytics
+        AICAnalytics.sendExhibitionBuyLinkEvent(exhibition: exhibition)
+        
+        if let ticketURLString = AppDataManager.sharedInstance.app.dataSettings[.ticketsUrl], let url = URL(string: ticketURLString) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+    }
+    
+    private func handleShowOnMap(with exhibition: AICExhibitionModel) {
+        dismiss()
+        coordinator.showExhibitionOnMap(exhibition)
+    }
+}

--- a/aic/SwiftUI Views/ExhibitionsGridView.swift
+++ b/aic/SwiftUI Views/ExhibitionsGridView.swift
@@ -1,0 +1,36 @@
+//
+//  ExhibitionsGridView.swift
+//  aic
+//
+//  Created by David Bireta on 2/18/26.
+//  Copyright © 2026 Art Institute of Chicago. All rights reserved.
+//
+
+import SwiftUI
+
+struct ExhibitionsGridView: View {
+    let exhibitions: [AICExhibitionModel]
+    
+    @State private var selectedExhibition: AICExhibitionModel?
+    
+    var body: some View {
+        ScrollView {
+            ForEach(exhibitions, id: \.id) { exhibit in
+                Button {
+                    selectedExhibition = exhibit
+                } label: {
+                    ExhibitionCard(title: exhibit.title, shortDescription: exhibit.shortDescription, endDate: exhibit.endDate ?? .distantFuture, imageURL: exhibit.imageUrl)
+                }
+                .foregroundStyle(.primary)
+            }
+        }
+        .navigationTitle("On View")
+        .sheet(item: $selectedExhibition) { exhibition in
+            ExhibitionDetailView(exhibition: exhibition)
+        }
+    }
+}
+
+#Preview {
+    ExhibitionsGridView(exhibitions: [])
+}

--- a/aic/SwiftUI Views/ExhibitionsGridView.swift
+++ b/aic/SwiftUI Views/ExhibitionsGridView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct ExhibitionsGridView: View {
     let exhibitions: [AICExhibitionModel]
     
+    @EnvironmentObject private var coordinator: HomeNavigationCoordinator
     @State private var selectedExhibition: AICExhibitionModel?
     
     var body: some View {
@@ -27,6 +28,8 @@ struct ExhibitionsGridView: View {
         .navigationTitle("On View")
         .sheet(item: $selectedExhibition) { exhibition in
             ExhibitionDetailView(exhibition: exhibition)
+                .environmentObject(coordinator)
+                .environment(\.locale, LanguageManager.sharedInstance.currentLocale)
         }
     }
 }

--- a/aic/SwiftUI Views/HomeNavigationCoordinator.swift
+++ b/aic/SwiftUI Views/HomeNavigationCoordinator.swift
@@ -1,0 +1,13 @@
+//
+//  HomeNavigationCoordinator.swift
+//  aic
+//
+//  Created by David Bireta on 4/9/26.
+//  Copyright © 2026 Art Institute of Chicago. All rights reserved.
+//
+
+import SwiftUI
+
+final class HomeNavigationCoordinator: ObservableObject {
+    var showExhibitionOnMap: (_ exhibition: AICExhibitionModel) -> Void = { _ in }
+}

--- a/aic/SwiftUI Views/HomeScreen.swift
+++ b/aic/SwiftUI Views/HomeScreen.swift
@@ -10,17 +10,11 @@ import SwiftUI
 
 struct HomeScreen: View {
     @ObservedObject var languageManager: LanguageManager
+    @EnvironmentObject private var coordinator: HomeNavigationCoordinator
 
+    @State private var selectedExhibition: AICExhibitionModel?
     @State private var scrollContentOffset: CGFloat = 0
     private let topSpacing = 60.0
-    
-    private var titleOpacity: Double {
-        if scrollContentOffset > -1 * topSpacing {
-            return 1
-        } else {
-            return 1 - abs((scrollContentOffset + topSpacing) / 50)
-        }
-    }
     
     var body: some View {
         ObservableScrollView(contentOffset: $scrollContentOffset) {
@@ -33,6 +27,42 @@ struct HomeScreen: View {
                     .foregroundStyle(.white)
                     .opacity(titleOpacity)
                     .scaleEffect(titleOpacity)
+                
+                VStack {
+                    // Exhibitions
+                    SwiftUI.Section {
+                        ScrollView(.horizontal) {
+                            HStack(alignment: .top, spacing: 16) {
+                                ForEach(exhibitions, id: \.id) { exhibition in
+                                    Button { selectedExhibition = exhibition } label: {
+                                        BigCard(title: exhibition.title, subtitle: LocalizedStringKey(exhibition.shortDescription), imageURL: exhibition.imageUrl, bottomOverlay: EmptyView())
+                                            .frame(width: 300)
+                                    }
+                                    .foregroundStyle(.primary)
+                                }
+                            }
+                            .requestScrollTargetLayout()
+                        }
+                        .requestScrollTargetBehavior()
+                        .requestContentMargins()
+                    } header: {
+                        HStack {
+                            Text(.Base.welcomeOnViewHeader)
+                                .aicOldFontStyle(.sectionHeader)
+                            Spacer()
+                            NavigationLink(value: ContentType.exhibitions) {
+                                Text(.Base.welcomeSeeAllAction)
+                                    .aicOldFontStyle(.overlay)
+                            }
+                        }
+                        .padding(.horizontal, 24)
+                    }
+                    .padding(.bottom)
+                    Divider()
+                        .padding(.horizontal)
+                        .padding(.bottom)
+                }
+                .background(.background)
             }
             .padding(.top, 64)
             .ignoresSafeArea(edges: .bottom)
@@ -51,16 +81,42 @@ struct HomeScreen: View {
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbarBackground(Color.homeBackground, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .sheet(item: $selectedExhibition) { exhibition in
+            ExhibitionDetailView(exhibition: exhibition)
+                .environment(\.locale, languageManager.currentLocale)
+        }
+        .navigationDestination(for: ContentType.self) { content in
+            switch content {
+                case .exhibitions: ExhibitionsGridView(exhibitions: exhibitions)
+                default: EmptyView()
+            }
+        }
         .environment(\.locale, languageManager.currentLocale)
     }
 }
 
 extension HomeScreen {
+    enum ContentType {
+        case tours, exhibitions, events
+    }
+    
+    private var exhibitions: [AICExhibitionModel] {
+        AppDataManager.sharedInstance.getExhibitionsForHome()
+    }
+    
     private var title: String {
         var resource = LocalizedStringResource("welcome_title", table: "Base")
         resource.locale = languageManager.currentLocale
         let translatedString = String(localized: resource)
         
         return translatedString
+    }
+    
+    private var titleOpacity: Double {
+        if scrollContentOffset > -1 * topSpacing {
+            return 1
+        } else {
+            return 1 - abs((scrollContentOffset + topSpacing) / 50)
+        }
     }
 }

--- a/aic/SwiftUI Views/HomeScreen.swift
+++ b/aic/SwiftUI Views/HomeScreen.swift
@@ -87,7 +87,10 @@ struct HomeScreen: View {
         }
         .navigationDestination(for: ContentType.self) { content in
             switch content {
-                case .exhibitions: ExhibitionsGridView(exhibitions: exhibitions)
+                case .exhibitions:
+                    ExhibitionsGridView(exhibitions: exhibitions)
+                        .environmentObject(coordinator)
+                    
                 default: EmptyView()
             }
         }

--- a/aic/SwiftUI Views/LocationSettingsView.swift
+++ b/aic/SwiftUI Views/LocationSettingsView.swift
@@ -66,14 +66,3 @@ extension LocationSettingsView {
 #Preview {
     LocationSettingsView()
 }
-
-struct AICButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .aicOldFontStyle(.actionButton)
-            .padding()
-            .padding(.horizontal)
-            .foregroundStyle(.white)
-            .background(Color.infoBackground)
-    }
-}

--- a/aic/SwiftUI Views/RemoteImage.swift
+++ b/aic/SwiftUI Views/RemoteImage.swift
@@ -1,0 +1,103 @@
+//
+//  RemoteImage.swift
+//  aic
+//
+//  Created by David Bireta on 2/20/26.
+//  Copyright © 2026 Art Institute of Chicago. All rights reserved.
+//
+
+import SwiftUI
+
+/// An alternative to `AsyncImage` that allows control over the caching mechanism.
+struct RemoteImage: View {
+    private enum LoadingState {
+        case loading, success, failure
+    }
+    
+    private let loadingImage = Image(systemName: "picture")
+    
+    private class Loader: ObservableObject {
+        var data = Data()
+        var state = LoadingState.loading
+        
+        private let logoCacheURL = URL.documentsDirectory.appending(path: "images")
+        
+        init(id: String, url: String) {
+            try? FileManager.default.createDirectory(at: logoCacheURL, withIntermediateDirectories: true)
+            
+            guard let urlString = URL(string: url) else {
+                return
+            }
+            
+            let docURL = logoCacheURL.appending(path: id+".jpg")
+            
+            if let cachedData = try? Data(contentsOf: docURL) {
+                self.data = cachedData
+                self.state = .success
+                return
+            }
+            
+            URLSession.shared.dataTask(with: urlString) { data, response, error in
+                DispatchQueue.main.async {
+                    if let data, data.count > 0, error == nil {
+                        self.data = data
+                        self.state = .success
+                        
+                        try? data.write(to: docURL)
+                    } else {
+                        self.state = .failure
+                    }
+                    
+                    self.objectWillChange.send()
+                }
+            }
+            .resume()
+        }
+    }
+    
+    @StateObject private var loader: Loader
+    
+    let imageID: String
+    let imageURL: URL?
+    let height: Double
+    
+    init(imageID: String, imageURL: URL?, height: Double = 240.0) {
+        _loader = StateObject(wrappedValue: Loader(id: imageID, url: imageURL?.absoluteString ?? ""))
+        self.imageID = imageID
+        self.imageURL = imageURL
+        self.height = height
+    }
+    
+    var body: some View {
+        Rectangle()
+            .fill(.background)
+            .frame(height: height)
+            .overlay {
+                switch loader.state {
+                    case .loading:
+                        Rectangle()
+                            .fill(.gray.gradient)
+                            .frame(height: height)
+                    case .success:
+                        image()
+                            .resizable()
+                            .scaledToFill()
+                            .border(.gray.opacity(0.25))
+                    case .failure:
+                        Rectangle()
+                            .fill(.red.gradient)
+                            .frame(height: height)
+                        
+                }
+            }
+            .clipped()
+    }
+    
+    private func image() -> Image {
+        if let image = UIImage(data: loader.data) {
+            return Image(uiImage: image)
+        } else {
+            return Image(systemName: "x.circle")
+        }
+    }
+}

--- a/aic/aic.xcodeproj/project.pbxproj
+++ b/aic/aic.xcodeproj/project.pbxproj
@@ -141,7 +141,11 @@
 		306E6E4D2469CA4D00B17CA8 /* MediaUI.strings in Resources */ = {isa = PBXBuildFile; fileRef = 306E6E172469CA4C00B17CA8 /* MediaUI.strings */; };
 		3099149B23A8385E00E32ACE /* InfoBuyTicketsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3099149A23A8385E00E32ACE /* InfoBuyTicketsView.swift */; };
 		8D3A29A92F86DA9200200C56 /* AccessCard.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8D3A29A82F86DA9200200C56 /* AccessCard.xcstrings */; };
+		8D3A2A392F8827F300200C56 /* ExhibitionCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3A2A2F2F8827F300200C56 /* ExhibitionCard.swift */; };
+		8D3A2A3A2F8827F300200C56 /* ExhibitionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3A2A302F8827F300200C56 /* ExhibitionDetailView.swift */; };
+		8D3A2A3B2F8827F300200C56 /* ExhibitionsGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3A2A312F8827F300200C56 /* ExhibitionsGridView.swift */; };
 		8D3A2A3C2F8827F300200C56 /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3A2A322F8827F300200C56 /* HomeScreen.swift */; };
+		8D3A2A3E2F8827F300200C56 /* RemoteImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3A2A332F8827F300200C56 /* RemoteImage.swift */; };
 		8D3A2A5F2F8831CA00200C56 /* Base.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8D3A2A5E2F8831CA00200C56 /* Base.xcstrings */; };
 		8D40F4F82F69F4CD00C3334D /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8D40F4F72F69F4CD00C3334D /* Colors.xcassets */; };
 		8D40F4FC2F69F65100C3334D /* AudioScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D40F4F92F69F65100C3334D /* AudioScreen.swift */; };
@@ -152,6 +156,7 @@
 		8D40F53E2F6B1AAB00C3334D /* InfoScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D40F53D2F6B1AAB00C3334D /* InfoScreen.swift */; };
 		8D40F5402F6B1AEF00C3334D /* ObservableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D40F53F2F6B1AEF00C3334D /* ObservableScrollView.swift */; };
 		8D40F5422F6B1D4700C3334D /* Info.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8D40F5412F6B1D4600C3334D /* Info.xcstrings */; };
+		8D4F9A012F8827F300200C56 /* HomeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4F9A002F8827F300200C56 /* HomeNavigationCoordinator.swift */; };
 		8D5960C32F84516E00267530 /* MemberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5960C22F84516E00267530 /* MemberView.swift */; };
 		8D919A752DD9363800FED627 /* GeneralCrashlyticsReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D919A742DD9363800FED627 /* GeneralCrashlyticsReport.swift */; };
 		8D9F2EC82F76D572008AEF5D /* LanguageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9F2EC72F76D572008AEF5D /* LanguageSettingsView.swift */; };
@@ -162,6 +167,8 @@
 		8DEEDF3B2F6C69E800FD54C6 /* LocationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DEEDF3A2F6C69E800FD54C6 /* LocationSettingsView.swift */; };
 		8DEEDF3D2F6C6BDA00FD54C6 /* Location.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8DEEDF3C2F6C6BD800FD54C6 /* Location.xcstrings */; };
 		8DEEDF412F6C73A900FD54C6 /* MuseumInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DEEDF402F6C73A900FD54C6 /* MuseumInfoView.swift */; };
+		8DF0C15F2F897227000C2938 /* AICButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF0C15E2F897227000C2938 /* AICButtonStyle.swift */; };
+		8DF0C1612F89772F000C2938 /* BigCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF0C1602F89772F000C2938 /* BigCard.swift */; };
 		E20B1C0829D525A90095E59C /* MapPointOfInterestType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20B1C0729D525A90095E59C /* MapPointOfInterestType.swift */; };
 		E218869429C0036F00803FF9 /* UIApplication+KeyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E218869329C0036F00803FF9 /* UIApplication+KeyWindow.swift */; };
 		E21D01B12BFD0C6100E75C53 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E21D01B02BFD0C6100E75C53 /* GoogleService-Info.plist */; };
@@ -403,7 +410,12 @@
 		306E6E432469CA4C00B17CA8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/MediaUI.strings; sourceTree = "<group>"; };
 		3099149A23A8385E00E32ACE /* InfoBuyTicketsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBuyTicketsView.swift; sourceTree = "<group>"; };
 		8D3A29A82F86DA9200200C56 /* AccessCard.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = AccessCard.xcstrings; sourceTree = "<group>"; };
+		8D3A2A2F2F8827F300200C56 /* ExhibitionCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionCard.swift; sourceTree = "<group>"; };
+		8D3A2A302F8827F300200C56 /* ExhibitionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailView.swift; sourceTree = "<group>"; };
+		8D3A2A312F8827F300200C56 /* ExhibitionsGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionsGridView.swift; sourceTree = "<group>"; };
 		8D3A2A322F8827F300200C56 /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
+		8D3A2A332F8827F300200C56 /* RemoteImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImage.swift; sourceTree = "<group>"; };
+		8D3A2A5E2F8831CA00200C56 /* Base.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Base.xcstrings; sourceTree = "<group>"; };
 		8D40F4F72F69F4CD00C3334D /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		8D40F4F92F69F65100C3334D /* AudioScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioScreen.swift; sourceTree = "<group>"; };
 		8D40F4FA2F69F65100C3334D /* StyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyleGuide.swift; sourceTree = "<group>"; };
@@ -413,6 +425,7 @@
 		8D40F53D2F6B1AAB00C3334D /* InfoScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoScreen.swift; sourceTree = "<group>"; };
 		8D40F53F2F6B1AEF00C3334D /* ObservableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableScrollView.swift; sourceTree = "<group>"; };
 		8D40F5412F6B1D4600C3334D /* Info.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Info.xcstrings; sourceTree = "<group>"; };
+		8D4F9A002F8827F300200C56 /* HomeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		8D5960C22F84516E00267530 /* MemberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberView.swift; sourceTree = "<group>"; };
 		8D919A742DD9363800FED627 /* GeneralCrashlyticsReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCrashlyticsReport.swift; sourceTree = "<group>"; };
 		8D9F2EC62F76D572008AEF5D /* LanguageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageManager.swift; sourceTree = "<group>"; };
@@ -423,6 +436,8 @@
 		8DEEDF3A2F6C69E800FD54C6 /* LocationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSettingsView.swift; sourceTree = "<group>"; };
 		8DEEDF3C2F6C6BD800FD54C6 /* Location.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Location.xcstrings; sourceTree = "<group>"; };
 		8DEEDF402F6C73A900FD54C6 /* MuseumInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuseumInfoView.swift; sourceTree = "<group>"; };
+		8DF0C15E2F897227000C2938 /* AICButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AICButtonStyle.swift; sourceTree = "<group>"; };
+		8DF0C1602F89772F000C2938 /* BigCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigCard.swift; sourceTree = "<group>"; };
 		8DF14D322E6FD10300E22443 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
 		E20B1C0729D525A90095E59C /* MapPointOfInterestType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPointOfInterestType.swift; sourceTree = "<group>"; };
 		E218869329C0036F00803FF9 /* UIApplication+KeyWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+KeyWindow.swift"; sourceTree = "<group>"; };
@@ -879,13 +894,20 @@
 				8D40F4FE2F69F6FB00C3334D /* Backports.swift */,
 				8D40F4FA2F69F65100C3334D /* StyleGuide.swift */,
 				8D9F2EC62F76D572008AEF5D /* LanguageManager.swift */,
+				8DF0C1602F89772F000C2938 /* BigCard.swift */,
 				8D40F4F92F69F65100C3334D /* AudioScreen.swift */,
 				8D40F53D2F6B1AAB00C3334D /* InfoScreen.swift */,
 				8D5960C22F84516E00267530 /* MemberView.swift */,
 				8DEEDF3A2F6C69E800FD54C6 /* LocationSettingsView.swift */,
+				8DF0C15E2F897227000C2938 /* AICButtonStyle.swift */,
 				8DEEDF402F6C73A900FD54C6 /* MuseumInfoView.swift */,
 				8D9F2EC72F76D572008AEF5D /* LanguageSettingsView.swift */,
+				8D3A2A2F2F8827F300200C56 /* ExhibitionCard.swift */,
+				8D3A2A302F8827F300200C56 /* ExhibitionDetailView.swift */,
+				8D3A2A312F8827F300200C56 /* ExhibitionsGridView.swift */,
 				8D3A2A322F8827F300200C56 /* HomeScreen.swift */,
+				8D3A2A332F8827F300200C56 /* RemoteImage.swift */,
+				8D4F9A002F8827F300200C56 /* HomeNavigationCoordinator.swift */,
 			);
 			path = "SwiftUI Views";
 			sourceTree = "<group>";
@@ -1416,6 +1438,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				05A2B2FB21024A780059C123 /* UILabelPadding.swift in Sources */,
+				8DF0C15F2F897227000C2938 /* AICButtonStyle.swift in Sources */,
 				294C0B60201A76F700F2ABB1 /* CoordinateConverter.swift in Sources */,
 				2915B0F0202BD73400DEBB03 /* AICAudioCommentaryModel.swift in Sources */,
 				E2C3486B2C2345E0007392BB /* DataParserCrashlyticsReport.swift in Sources */,
@@ -1521,7 +1544,12 @@
 				E433BACF1CFDD64A0086F2ED /* AppDelegate.swift in Sources */,
 				E4F7AF951CFB64DE00524F87 /* AICMapModel.swift in Sources */,
 				E4E108DC1C98A89A00385842 /* AICAudioFileModel.swift in Sources */,
+				8D3A2A392F8827F300200C56 /* ExhibitionCard.swift in Sources */,
+				8D3A2A3A2F8827F300200C56 /* ExhibitionDetailView.swift in Sources */,
+				8D3A2A3B2F8827F300200C56 /* ExhibitionsGridView.swift in Sources */,
 				8D3A2A3C2F8827F300200C56 /* HomeScreen.swift in Sources */,
+				8D3A2A3E2F8827F300200C56 /* RemoteImage.swift in Sources */,
+				8D4F9A012F8827F300200C56 /* HomeNavigationCoordinator.swift in Sources */,
 				8D919A752DD9363800FED627 /* GeneralCrashlyticsReport.swift in Sources */,
 				E4F518FB1D2586B0004BFB44 /* AICImageView.swift in Sources */,
 				8D40F5402F6B1AEF00C3334D /* ObservableScrollView.swift in Sources */,
@@ -1579,6 +1607,7 @@
 				E4D159391CBAE8C100536B4D /* AICCoordinateWithFloor.swift in Sources */,
 				E458502F1CAC8C1A00131A66 /* AICExhibitionModel.swift in Sources */,
 				E47A97151CEFBC150041D0A6 /* AppDataManager.swift in Sources */,
+				8DF0C1612F89772F000C2938 /* BigCard.swift in Sources */,
 				0E2D15591DA8134200D06A4A /* AICMemberCardModel.swift in Sources */,
 				2902E0B01FC47FF60070C78C /* InfoButton.swift in Sources */,
 				E2C3486A2C2345E0007392BB /* CrashlyticsService.swift in Sources */,

--- a/aic/aic/Models/AICExhibitionModel.swift
+++ b/aic/aic/Models/AICExhibitionModel.swift
@@ -40,3 +40,5 @@ class AICExhibitionModel: NSObject {
 		super.init()
 	}
 }
+
+extension AICExhibitionModel: Identifiable {}

--- a/aic/aic/ViewControllers+Views/Sections/Home/HomeNavigationController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Home/HomeNavigationController.swift
@@ -16,10 +16,12 @@ protocol HomeNavigationControllerDelegate: AnyObject {
 	func showExhibitionCard(exhibition: AICExhibitionModel)
 	func showEventCard(event: AICEventModel)
     func showSearch()
+    func showExhibitionOnMap(exhibition: AICExhibitionModel)
 }
 
 class HomeNavigationController: SectionNavigationController {
 	let homeVC: HomeViewController
+    let coordinator = HomeNavigationCoordinator()
 
 	weak var sectionDelegate: HomeNavigationControllerDelegate?
 
@@ -34,6 +36,10 @@ class HomeNavigationController: SectionNavigationController {
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
+        
+        coordinator.showExhibitionOnMap = { [weak self] exhibition in
+            self?.sectionDelegate?.showExhibitionOnMap(exhibition: exhibition)
+        }
 
 
         let home = NavigationStack {
@@ -47,6 +53,7 @@ class HomeNavigationController: SectionNavigationController {
                     .foregroundStyle(.white)
                 }
                 .environment(\.locale, LanguageManager.sharedInstance.currentLocale)
+               .environmentObject(coordinator)
         }
         let rootVC = UIHostingController(rootView: home)
         

--- a/aic/aic/ViewControllers+Views/Sections/Home/HomeNavigationController.swift
+++ b/aic/aic/ViewControllers+Views/Sections/Home/HomeNavigationController.swift
@@ -53,7 +53,7 @@ class HomeNavigationController: SectionNavigationController {
                     .foregroundStyle(.white)
                 }
                 .environment(\.locale, LanguageManager.sharedInstance.currentLocale)
-               .environmentObject(coordinator)
+                .environmentObject(coordinator)
         }
         let rootVC = UIHostingController(rootView: home)
         


### PR DESCRIPTION
This PR adds the necessary UI elements to:

- Display the scrolling carousel of exhibitions on the home screen
- Provide a secondary grid when See All is tapped
- Display exhibition details in a sheet when a specific item is tapped
- Connect the Buy Tickets and Show on Map buttons