### PR TITLE
Convert HTML content to markdown.

### DIFF
--- a/aic/SwiftUI Views/EventDetailView.swift
+++ b/aic/SwiftUI Views/EventDetailView.swift
@@ -45,9 +45,10 @@ struct EventDetailView: View {
                     
                     if let caption = event.buttonCaption, caption.isEmpty == false {
                         Text(LocalizedStringKey(caption))
+                            .aicOldFontStyle(.infoMenuText)
                             .frame(maxWidth: .infinity)
                             .multilineTextAlignment(.center)
-                            .padding(.bottom)
+                            .padding(.vertical)
                     }
                     
                     Text(LocalizedStringKey(event.longDescription))

--- a/aic/aic.xcodeproj/project.pbxproj
+++ b/aic/aic.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		8D3A2A3F2F8827F300200C56 /* ToursGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3A2A362F8827F300200C56 /* ToursGridView.swift */; };
 		8D3A2A402F8827F300200C56 /* EventDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3A2A2D2F8827F300200C56 /* EventDetailView.swift */; };
 		8D3A2A412F8827F300200C56 /* TourDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3A2A352F8827F300200C56 /* TourDetailView.swift */; };
+		8D3A2A5D2F882A8800200C56 /* Demark in Frameworks */ = {isa = PBXBuildFile; productRef = 8D3A2A5C2F882A8800200C56 /* Demark */; };
 		8D3A2A5F2F8831CA00200C56 /* Base.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8D3A2A5E2F8831CA00200C56 /* Base.xcstrings */; };
 		8D40F4F82F69F4CD00C3334D /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8D40F4F72F69F4CD00C3334D /* Colors.xcassets */; };
 		8D40F4FC2F69F65100C3334D /* AudioScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D40F4F92F69F65100C3334D /* AudioScreen.swift */; };
@@ -531,6 +532,7 @@
 				E28F3B1229BAC28E00C03BFD /* Atributika in Frameworks */,
 				E28F3AFE29B96E6A00C03BFD /* FirebaseAuth in Frameworks */,
 				E28F3B0C29BAC1F900C03BFD /* SwiftyJSON in Frameworks */,
+				8D3A2A5D2F882A8800200C56 /* Demark in Frameworks */,
 				E28F3B0329BAC14A00C03BFD /* Kingfisher in Frameworks */,
 				E28F3B1529BAC33300C03BFD /* Localize_Swift in Frameworks */,
 				E28F3B0029B96E6A00C03BFD /* FirebaseCrashlytics in Frameworks */,
@@ -1254,6 +1256,7 @@
 				E28F3B1129BAC28E00C03BFD /* Atributika */,
 				E28F3B1429BAC33300C03BFD /* Localize_Swift */,
 				E276C4002AC5909B007A5917 /* PureLayout */,
+				8D3A2A5C2F882A8800200C56 /* Demark */,
 			);
 			productName = aic;
 			productReference = E40D41C91C6CEBB700A57AF4 /* aic.app */;
@@ -1354,6 +1357,7 @@
 				E28F3B1029BAC28E00C03BFD /* XCRemoteSwiftPackageReference "Atributika" */,
 				E28F3B1329BAC33300C03BFD /* XCRemoteSwiftPackageReference "Localize-Swift" */,
 				E276C3FF2AC5909B007A5917 /* XCRemoteSwiftPackageReference "PureLayout" */,
+				8D3A2A5B2F882A8800200C56 /* XCRemoteSwiftPackageReference "Demark" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E40D41CA1C6CEBB700A57AF4 /* Products */;
@@ -2237,6 +2241,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		8D3A2A5B2F882A8800200C56 /* XCRemoteSwiftPackageReference "Demark" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/steipete/Demark.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
+			};
+		};
 		E276C3FF2AC5909B007A5917 /* XCRemoteSwiftPackageReference "PureLayout" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/PureLayout/PureLayout.git";
@@ -2304,6 +2316,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		8D3A2A5C2F882A8800200C56 /* Demark */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8D3A2A5B2F882A8800200C56 /* XCRemoteSwiftPackageReference "Demark" */;
+			productName = Demark;
+		};
 		E276C4002AC5909B007A5917 /* PureLayout */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E276C3FF2AC5909B007A5917 /* XCRemoteSwiftPackageReference "PureLayout" */;

--- a/aic/aic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/aic/aic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e560b5f1dff81670d19e009b9f0358dfb2327144879ec4c25bbfa5e774ad8abf",
+  "originHash" : "c83a1af683ad45cc54b0a6f0336b265872bc0cef1dbdb761c25c9907c7069927",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "d018897afbd55d9065ef859650585bac890ada7e",
         "version" : "4.10.1"
+      }
+    },
+    {
+      "identity" : "demark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/steipete/Demark.git",
+      "state" : {
+        "revision" : "9d12266c98f51099beec92e50483392869b12d77",
+        "version" : "1.1.0"
       }
     },
     {

--- a/aic/aic/Data/AppDataManager.swift
+++ b/aic/aic/Data/AppDataManager.swift
@@ -283,8 +283,9 @@ final class AppDataManager {
                             let denmark = await Demark()
                             
                             for exhibition in self.exhibitions {
-                                let markdown = try! await denmark.convertToMarkdown(exhibition.shortDescription.cleanedHTML, options: self.markdownOptions)
-                                exhibition.shortDescription = markdown
+                                if let markdown = try? await denmark.convertToMarkdown(exhibition.shortDescription.cleanedHTML, options: self.markdownOptions) {
+                                    exhibition.shortDescription = markdown
+                                }
                             }
                         }
 
@@ -362,14 +363,18 @@ final class AppDataManager {
                             let denmark = await Demark()
                             
                             for event in self.events {
-                                let shortMarkdown = try! await denmark.convertToMarkdown(event.shortDescription.cleanedHTML, options: self.markdownOptions)
-                                let longMarkdown = try! await denmark.convertToMarkdown(event.longDescription.cleanedHTML, options: self.markdownOptions)
-                                let buttonMarkdown = try! await denmark.convertToMarkdown(event.buttonCaption?.cleanedHTML ?? "", options: self.markdownOptions)
-
                                 if let index = self.events.firstIndex(of: event) {
-                                    self.events[index].shortDescription = shortMarkdown
-                                    self.events[index].longDescription = longMarkdown
-                                    self.events[index].buttonCaption = buttonMarkdown
+                                    if let shortMarkdown = try? await denmark.convertToMarkdown(event.shortDescription.cleanedHTML, options: self.markdownOptions) {
+                                        self.events[index].shortDescription = shortMarkdown
+                                    }
+                                    
+                                    if let longMarkdown = try? await denmark.convertToMarkdown(event.longDescription.cleanedHTML, options: self.markdownOptions) {
+                                        self.events[index].longDescription = longMarkdown
+                                    }
+                                    
+                                    if let buttonMarkdown = try? await denmark.convertToMarkdown(event.buttonCaption?.cleanedHTML ?? "", options: self.markdownOptions) {
+                                        self.events[index].buttonCaption = buttonMarkdown
+                                    }
                                 }
                             }
                         }

--- a/aic/aic/Data/AppDataManager.swift
+++ b/aic/aic/Data/AppDataManager.swift
@@ -3,8 +3,9 @@ Abstract:
 Manager class that handles loading and manipulating the apps data sources
 */
 
-import UIKit
 import Alamofire
+import Demark
+import UIKit
 
 @objc protocol AppDataManagerDelegate: AnyObject {
 	func downloadProgress(withPctCompleted: Float)
@@ -31,6 +32,7 @@ final class AppDataManager {
 	private var loadFailure = false
     private let dataParser: AppDataParser
     private let configuration: ConfigurationResources
+    private let markdownOptions = DemarkOptions(engine: .htmlToMd, ignoreTags: ["span", "br"])
 
     private init() {
         dataParser = AppDataParser(
@@ -276,6 +278,15 @@ final class AppDataManager {
 				switch response.result {
 				case .success(let value):
                         self.exhibitions = self.dataParser.parse(exhibitionsData: value).sorted(by: { $0.position < $1.position })
+                        
+                        Task {
+                            let denmark = await Demark()
+                            
+                            for exhibition in self.exhibitions {
+                                let markdown = try! await denmark.convertToMarkdown(exhibition.shortDescription.cleanedHTML, options: self.markdownOptions)
+                                exhibition.shortDescription = markdown
+                            }
+                        }
 
 				case .failure(let error):
 					debugPrint(error)
@@ -288,7 +299,7 @@ final class AppDataManager {
 
 	// MARK: Download Events
 
-	func downloadEvents() {
+	private func downloadEvents() {
 		var url: String = app.dataSettings[.dataApiUrl]! + app.dataSettings[.eventsEndpoint]!
 		if url.range(of: "/search") == nil {
 			url.append("/search")
@@ -340,18 +351,35 @@ final class AppDataManager {
 			]
 		]
 
-		AF.request(urlString!, method: .post, parameters: parameters, encoding: JSONEncoding.default)
-			.validate()
-			.responseData { response in
-				switch response.result {
-				case .success(let value):
-					self.events = self.dataParser.parse(eventsData: value)
-				case .failure(let error):
-					debugPrint(error)
-				}
-				self.updateDownloadProgress()
-		}
-	}
+        AF.request(urlString!, method: .post, parameters: parameters, encoding: JSONEncoding.default)
+            .validate()
+            .responseData { response in
+                switch response.result {
+                    case .success(let value):
+                        self.events = self.dataParser.parse(eventsData: value)
+                        
+                        Task {
+                            let denmark = await Demark()
+                            
+                            for event in self.events {
+                                let shortMarkdown = try! await denmark.convertToMarkdown(event.shortDescription.cleanedHTML, options: self.markdownOptions)
+                                let longMarkdown = try! await denmark.convertToMarkdown(event.longDescription.cleanedHTML, options: self.markdownOptions)
+                                let buttonMarkdown = try! await denmark.convertToMarkdown(event.buttonCaption?.cleanedHTML ?? "", options: self.markdownOptions)
+
+                                if let index = self.events.firstIndex(of: event) {
+                                    self.events[index].shortDescription = shortMarkdown
+                                    self.events[index].longDescription = longMarkdown
+                                    self.events[index].buttonCaption = buttonMarkdown
+                                }
+                            }
+                        }
+                    case .failure(let error):
+                        debugPrint(error)
+                }
+                
+                self.updateDownloadProgress()
+            }
+    }
 
 	// MARK: Fetch Member Card if Needed
 

--- a/aic/aic/Models/AICEventModel.swift
+++ b/aic/aic/Models/AICEventModel.swift
@@ -11,8 +11,8 @@ import CoreLocation
 struct AICEventModel {
 	let eventId: String
 	let title: String
-	let shortDescription: String
-	let longDescription: String
+	var shortDescription: String
+	var longDescription: String
 
 	let imageUrl: URL
 
@@ -22,7 +22,7 @@ struct AICEventModel {
 
 	let eventUrl: URL?
 	let buttonText: String
-    let buttonCaption: String?
+    var buttonCaption: String?
     let isTicketed: Bool
     let isSalesButtonHidden: Bool
     let onSaleDate: Date?

--- a/aic/aic/Models/AICExhibitionModel.swift
+++ b/aic/aic/Models/AICExhibitionModel.swift
@@ -8,7 +8,7 @@ import CoreLocation
 class AICExhibitionModel: NSObject {
 	let id: Int
 	let title: String
-	let shortDescription: String
+	var shortDescription: String
 	var imageUrl: URL?
 	let startDate: Date
 	let endDate: Date?

--- a/aic/aic/Shared/Extensions/String+AIC.swift
+++ b/aic/aic/Shared/Extensions/String+AIC.swift
@@ -444,4 +444,12 @@ extension String {
         
         return result
     }
+    
+    var cleanedHTML: String {
+        self
+            .replacingOccurrences(of: "</p>", with: "</p>\n\n")
+            .replacingOccurrences(of: "<li>", with: "\n<li>•\t")
+            .replacingOccurrences(of: "</h2>", with: "</h2>\n")
+            .replacingOccurrences(of: "<br class=\"softbreak\"></strong>", with: "</strong><br>")
+    }
 }


### PR DESCRIPTION
Displaying HTML content that uses a custom font, responds to changes in dynamic type, and integrates well with the SwiftUI layout system has been surprisingly challenging. As an alternative, Markdown looks to work nicely across all those requirements.

While I am a bit hesitant to be adding another dependency, Demark looks to be well written and maintained, and covers numerous edge cases in the html to markdown conversion process.