### PR TITLE
Show building hours and directions directly in the app.

### DIFF
--- a/aic/SwiftUI Views/InfoScreen.swift
+++ b/aic/SwiftUI Views/InfoScreen.swift
@@ -136,7 +136,7 @@ struct InfoScreen: View {
                     LocationSettingsView()
                         .environment(\.locale, language.currentLocale)
                 case .museumInfo:
-                    MuseumInfoView()
+                    MuseumInfoView(buildingHours: AppDataManager.sharedInstance.buildingHours!)
                         .environment(\.locale, language.currentLocale)
                 case .languageSettings:
                     LanguageSettingsView(languageManager: LanguageManager.sharedInstance)

--- a/aic/SwiftUI Views/MuseumInfoView.swift
+++ b/aic/SwiftUI Views/MuseumInfoView.swift
@@ -9,37 +9,118 @@
 import SwiftUI
 
 struct MuseumInfoView: View {
+    let buildingHours: AICBuildingHours
+    
     var body: some View {
-        VStack(spacing: 24) {
-            Text(.Info.museumInfoAction)
-                .aicOldFontStyle(.audioButton)
-            
-            Divider()
-            
-            Text(.Info.infoMuseumHours)
-                .aicOldFontStyle(.infoMenuText)
-                .multilineTextAlignment(.center)
-                .padding(.bottom)
-            
-            Text("111 S Michigan Ave")
-                .aicOldFontStyle(.infoMenuText)
-            
-            Text("Chicago, IL 60603")
-                .aicOldFontStyle(.infoMenuText)
-                .padding(.bottom)
-            
-            Text("+1 312 443 3600")
-                .aicOldFontStyle(.infoMenuText)
-            
-            Spacer()
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text(.Info.museumInfoAction)
+                    .aicOldFontStyle(.audioButton)
+                    .frame(maxWidth: .infinity)
+                
+                Divider()
+                
+                Label("Hours", systemImage: "clock")
+                    .aicOldFontStyle(.infoMenuText)
+                
+                Text(buildingHours.data.first?.additional_text ?? "no hours")
+                    .foregroundStyle(.secondary)
+
+                VStack {
+                    HStack {
+                        Text(weekdayNames[1])
+                        Spacer()
+                        Text(buildingHours.displayString(for: .monday))
+                    }
+                    Divider()
+
+                    HStack {
+                        Text(weekdayNames[2])
+                        Spacer()
+                        Text(buildingHours.displayString(for: .tuesday))
+                    }
+                    .foregroundStyle(.secondary)
+                    Divider()
+
+                    HStack {
+                        Text(weekdayNames[3])
+                        Spacer()
+                        Text(buildingHours.displayString(for: .wednesday))
+                    }
+                    Divider()
+
+                    HStack {
+                        Text(weekdayNames[4])
+                        Spacer()
+                        Text(buildingHours.displayString(for: .thursday))
+                    }
+                    Divider()
+
+                    HStack {
+                        Text("\(weekdayNames[5]) - \(weekdayNames[0])")
+                        Spacer()
+                        Text(buildingHours.displayString(for: .friday))
+                    }
+                }
+                
+                // TODO: This is not included in the /hours response
+                Text("The museum is closed Thanksgiving, Christmas, and New Year's Day.")
+                    .foregroundStyle(.secondary)
+                    .padding(.bottom, 48)
+                
+                // Map Info
+                VStack(alignment: .leading, spacing: 12) {
+                    Label("Location and Directions", systemImage: "location.circle")
+                        .aicOldFontStyle(.infoMenuText)
+                    
+                    VStack(alignment: .leading) {
+                        Text("**Michigan Avenue Entrance**")
+                        Button {
+                            let mapURL = URL(string: "http://maps.apple.com/?address=111,S,Michigan,Ave,Chicago,IL,60603")!
+                            UIApplication.shared.open(mapURL)
+                        } label: {
+                            VStack(alignment: .leading) {
+                                Text("111 S Michigan Ave")
+                                Text("Chicago, IL 60603")
+                            }
+                            .aicOldFontStyle(.infoMenuText)
+                        }
+                    }
+                    .padding(.bottom, 12)
+                    
+                    VStack(alignment: .leading) {
+                        Text("**Modern Wing Entrance**")
+                        Button {
+                            let mapURL = URL(string: "http://maps.apple.com/?address=159,East,Monroe,Street")!
+                            UIApplication.shared.open(mapURL)
+                        } label: {
+                            VStack(alignment: .leading) {
+                                Text("159 East Monroe Street")
+                                Text("Chicago, IL 60603")
+                            }
+                            .aicOldFontStyle(.infoMenuText)
+                        }
+                    }
+                }
+                
+                Spacer()
+            }
+            .aicOldFontStyle(.infoMenuText)
+            .padding()
+            .toolbarBackground(.infoBackground, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
         }
-        .padding()
-        .toolbarBackground(.infoBackground, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
-        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+}
+
+extension MuseumInfoView {
+    private var weekdayNames: [String] {
+        let cal = Calendar.current
+        return cal.weekdaySymbols
     }
 }
 
 #Preview {
-    MuseumInfoView()
+    MuseumInfoView(buildingHours: .preview)
 }

--- a/aic/aic.xcodeproj/project.pbxproj
+++ b/aic/aic.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		8D9F2ECB2F76D589008AEF5D /* LocalizationUI.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8D9F2ECA2F76D589008AEF5D /* LocalizationUI.xcstrings */; };
 		8DA06C292F3502FA00D15056 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DA06C282F3502FA00D15056 /* SceneDelegate.swift */; };
 		8DB858F32D8B6E11009E9B1B /* Array+AIC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DB858F22D8B6E11009E9B1B /* Array+AIC.swift */; };
+		8DECAA682F9FF35200E12A85 /* AICBuildingHours.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DECAA672F9FF35200E12A85 /* AICBuildingHours.swift */; };
 		8DEEDF3B2F6C69E800FD54C6 /* LocationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DEEDF3A2F6C69E800FD54C6 /* LocationSettingsView.swift */; };
 		8DEEDF3D2F6C6BDA00FD54C6 /* Location.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8DEEDF3C2F6C6BD800FD54C6 /* Location.xcstrings */; };
 		8DEEDF412F6C73A900FD54C6 /* MuseumInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DEEDF402F6C73A900FD54C6 /* MuseumInfoView.swift */; };
@@ -444,6 +445,7 @@
 		8D9F2ECA2F76D589008AEF5D /* LocalizationUI.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = LocalizationUI.xcstrings; sourceTree = "<group>"; };
 		8DA06C282F3502FA00D15056 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		8DB858F22D8B6E11009E9B1B /* Array+AIC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+AIC.swift"; sourceTree = "<group>"; };
+		8DECAA672F9FF35200E12A85 /* AICBuildingHours.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AICBuildingHours.swift; sourceTree = "<group>"; };
 		8DEEDF3A2F6C69E800FD54C6 /* LocationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSettingsView.swift; sourceTree = "<group>"; };
 		8DEEDF3C2F6C6BD800FD54C6 /* Location.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Location.xcstrings; sourceTree = "<group>"; };
 		8DEEDF402F6C73A900FD54C6 /* MuseumInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuseumInfoView.swift; sourceTree = "<group>"; };
@@ -1089,6 +1091,7 @@
 		E415ABBD1C7298420093B719 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				8DECAA672F9FF35200E12A85 /* AICBuildingHours.swift */,
 				E497FA5B1CFF3803007FA272 /* AICAppDataModel.swift */,
 				2915B0EF202BD73400DEBB03 /* AICAudioCommentaryModel.swift */,
 				E4E108DB1C98A89A00385842 /* AICAudioFileModel.swift */,
@@ -1643,6 +1646,7 @@
 				29F12BC2204F4C37009C1A47 /* MapTourStartContentView.swift in Sources */,
 				2994891F1FA3849C00943197 /* AICGeneralInfoModel.swift in Sources */,
 				2984611E203A046C001E5378 /* MapTextContentView.swift in Sources */,
+				8DECAA682F9FF35200E12A85 /* AICBuildingHours.swift in Sources */,
 				294338541FDD5FC900ECF321 /* MapItemsCollectionContainerCell.swift in Sources */,
 				E2447C732BFC0B0C0016A590 /* ParseError.swift in Sources */,
 			);

--- a/aic/aic/Data/AppDataManager.swift
+++ b/aic/aic/Data/AppDataManager.swift
@@ -19,6 +19,7 @@ final class AppDataManager {
     private(set) var app = AICAppDataModel(generalInfo: .init(translations: [:]), map: .init(floors: []))
 	private(set) var exhibitions = [AICExhibitionModel]()
 	private(set) var events = [AICEventModel]()
+    private(set) var buildingHours: AICBuildingHours?
 
 	private var dataFilesRetrieved = 0
 	var pctComplete = Float(0)
@@ -222,6 +223,10 @@ final class AppDataManager {
 				self.app = self.dataParser.parse(appData: appData)
 				self.updateDownloadProgress()
 				self.downloadExhibitions()
+                
+                Task {
+                    await self.downloadBuildingHours()
+                }
 			} else {
 				// If we couldn't load some floor pdfs let the user know
 				self.notifyLoadFailure(withMessage: "Failed to load application data.")
@@ -229,7 +234,23 @@ final class AppDataManager {
 			}
 		}
 	}
+    
+    private func downloadBuildingHours() async {
+        do {
+            guard let baseURL = app.dataSettings[.dataApiUrl] else { return }
+            guard let url = URL(string: baseURL) else { return }
+            
+            
+            let buildingHoursURL = url.appending(path: "api/v1/hours").appending(queryItems: [.init(name: "limit", value: "2")])
+            let (data, _) = try await URLSession.shared.data(from: buildingHoursURL)
+            let hours = try JSONDecoder().decode(AICBuildingHours.self, from: data)
+            self.buildingHours = hours
+        } catch {
+            print("WARN: Unable to fetch building hours: \(error.localizedDescription)")
+        }
+    }
 
+    
 	// MARK: Download Exhibitions
 
 	private func downloadExhibitions() {

--- a/aic/aic/Models/AICBuildingHours.swift
+++ b/aic/aic/Models/AICBuildingHours.swift
@@ -1,0 +1,170 @@
+//
+//  AICBuildingHours.swift
+//  aic
+//
+//  Created by David Bireta on 3/2/26.
+//  Copyright © 2026 Art Institute of Chicago. All rights reserved.
+//
+
+import Foundation
+
+struct AICBuildingHours: Decodable {
+    let data: [ResponseData]
+    
+    struct ResponseData: Decodable {
+        let id: Int
+        let additional_text: String
+        let updated_at: String
+        let monday_is_closed: Bool
+        let monday_member_open: String
+        let monday_member_close: String
+        let monday_public_open: String
+        let monday_public_close: String
+        let tuesday_is_closed: Bool
+        let tuesday_member_open: String?
+        let tuesday_member_close: String?
+        let tuesday_public_open: String?
+        let tuesday_public_close: String?
+        let wednesday_is_closed: Bool
+        let wednesday_member_open: String
+        let wednesday_member_close: String
+        let wednesday_public_open: String
+        let wednesday_public_close: String
+        let thursday_is_closed: Bool
+        let thursday_member_open: String
+        let thursday_member_close: String
+        let thursday_public_open: String
+        let thursday_public_close: String
+        let friday_member_open: String
+        let friday_member_close: String
+        let friday_public_open: String
+        let friday_public_close: String
+        let friday_is_closed: Bool
+        let saturday_is_closed: Bool
+        let saturday_member_open: String
+        let saturday_member_close: String
+        let saturday_public_open: String
+        let saturday_public_close: String
+        let sunday_is_closed: Bool
+        let sunday_member_open: String
+        let sunday_member_close: String
+        let sunday_public_open: String
+        let sunday_public_close: String
+    }
+    
+    func displayString(for day: Locale.Weekday) -> String {
+        switch day {
+            case .monday:
+                guard data.first?.monday_is_closed == false else { return "Closed" }
+                return "\(openHour(for: .monday)?.hour, default: "") - \(closeHour(for: .monday)?.hour, default: "")"
+            case .tuesday:
+                guard data.first?.tuesday_is_closed == false else { return "Closed" }
+                return "\(openHour(for: .tuesday)?.hour, default: "") - \(closeHour(for: .tuesday)?.hour, default: "")"
+            case .wednesday:
+                guard data.first?.wednesday_is_closed == false else { return "Closed" }
+                return "\(openHour(for: .wednesday)?.hour, default: "") - \(closeHour(for: .wednesday)?.hour, default: "")"
+            case .thursday:
+                guard data.first?.thursday_is_closed == false else { return "Closed" }
+                return "\(openHour(for: .thursday)?.hour, default: "") - \(closeHour(for: .thursday)?.hour, default: "")"
+            case .friday:
+                // This includes Friday - Sunday
+                guard data.first?.friday_is_closed == false else { return "Closed" }
+                return "\(openHour(for: .friday)?.hour, default: "") - \(closeHour(for: .sunday)?.hour, default: "")"
+            default:
+                return ""
+        }
+    }
+    
+    func openHour(for day: Locale.Weekday) -> DateComponents? {
+        timeString(for: day, isOpen: true).flatMap { parse($0) }
+    }
+
+    func closeHour(for day: Locale.Weekday) -> DateComponents? {
+        timeString(for: day, isOpen: false).flatMap { parse($0) }
+    }
+
+    private func timeString(for day: Locale.Weekday, isOpen: Bool) -> String? {
+        guard let row = data.first else { return nil }
+        
+        switch day {
+            case .monday:
+                return isOpen ? row.monday_public_open : row.monday_public_close
+            case .tuesday:
+                return isOpen ? row.tuesday_public_open : row.tuesday_public_close
+            case .wednesday:
+                return isOpen ? row.wednesday_public_open : row.wednesday_public_close
+            case .thursday:
+                return isOpen ? row.thursday_public_open : row.thursday_public_close
+            case .friday:
+                return isOpen ? row.friday_public_open : row.friday_public_close
+            case .saturday:
+                return isOpen ? row.saturday_public_open : row.saturday_public_close
+            case .sunday:
+                return isOpen ? row.sunday_public_open : row.sunday_public_close
+            @unknown default:
+                return nil
+        }
+    }
+
+    private func parse(_ timeString: String) -> DateComponents? {
+        let pattern = #/PT(\d+)H(\d+)M/#
+
+        if let match = timeString.firstMatch(of: pattern) {
+            let hour = Int(match.1)
+            let minute = Int(match.2)
+
+            return DateComponents(hour: hour, minute: minute)
+        }
+
+        return nil
+    }
+}
+
+#if DEBUG
+extension AICBuildingHours {
+    static var preview: AICBuildingHours {
+        AICBuildingHours(data: [
+            ResponseData(
+                id: 1,
+                additional_text: "The first hour of every day, 10-11 a.m., is reserved for member-only viewing.",
+                updated_at: "2026-04-01T00:00:00Z",
+                monday_is_closed: false,
+                monday_member_open: "PT10H00M",
+                monday_member_close: "PT17H00M",
+                monday_public_open: "PT10H00M",
+                monday_public_close: "PT17H00M",
+                tuesday_is_closed: true,
+                tuesday_member_open: "PT9H00M",
+                tuesday_member_close: "PT17H00M",
+                tuesday_public_open: "PT10H00M",
+                tuesday_public_close: "PT17H00M",
+                wednesday_is_closed: false,
+                wednesday_member_open: "PT9H00M",
+                wednesday_member_close: "PT17H00M",
+                wednesday_public_open: "PT10H00M",
+                wednesday_public_close: "PT17H00M",
+                thursday_is_closed: false,
+                thursday_member_open: "PT9H00M",
+                thursday_member_close: "PT20H00M",
+                thursday_public_open: "PT10H00M",
+                thursday_public_close: "PT20H00M",
+                friday_member_open: "PT9H00M",
+                friday_member_close: "PT17H00M",
+                friday_public_open: "PT10H00M",
+                friday_public_close: "PT17H00M",
+                friday_is_closed: false,
+                saturday_is_closed: false,
+                saturday_member_open: "PT9H00M",
+                saturday_member_close: "PT17H00M",
+                saturday_public_open: "PT10H00M",
+                saturday_public_close: "PT17H00M",
+                sunday_is_closed: false,
+                sunday_member_open: "PT9H00M",
+                sunday_member_close: "PT17H00M",
+                sunday_public_open: "PT10H00M",
+                sunday_public_close: "PT17H00M"
+            )
+        ])
+    }
+}
+#endif


### PR DESCRIPTION
This uses the `/hours` API endpoint to display the available visiting hours directly in the app. 

Addresses to both entrances are also provided, which when tapped will open the Maps app to provide navigation directions.