### PR TITLE
Remove the DEBUG macro around the sample data.

### DIFF
--- a/aic/aic/Models/AICBuildingHours.swift
+++ b/aic/aic/Models/AICBuildingHours.swift
@@ -120,7 +120,6 @@ struct AICBuildingHours: Decodable {
     }
 }
 
-#if DEBUG
 extension AICBuildingHours {
     static var preview: AICBuildingHours {
         AICBuildingHours(data: [
@@ -167,4 +166,3 @@ extension AICBuildingHours {
         ])
     }
 }
-#endif


### PR DESCRIPTION
Although the #Preview where this sample data gets used is eventually removed from the release build, Xcode still builds it first. Therefore the `preview` property still needs to be available for a Release build. Fortunately it is pretty small, and is only referenced in the #Preview, so it shouldn’t really cause any issues.