### PR TITLE
Resize event thumbnail to match cache

### DIFF
--- a/aic/SwiftUI Views/EventsGridView.swift
+++ b/aic/SwiftUI Views/EventsGridView.swift
@@ -29,6 +29,7 @@ struct EventsGridView: View {
                 }
             }
         }
+        .scrollIndicators(.hidden)
         .padding(.horizontal)
         .navigationTitle("Events")
         .navigationDestination(for: AICEventModel.self) { event in

--- a/aic/SwiftUI Views/HomeScreen.swift
+++ b/aic/SwiftUI Views/HomeScreen.swift
@@ -128,7 +128,7 @@ struct HomeScreen: View {
                                     Button {
                                         selectedEvent = event
                                     } label: {
-                                        BigCard(title: event.title, subtitle: LocalizedStringKey(event.shortDescription), imageURL: event.imageUrl, bottomOverlay: Text(event.startDate.formatted(.dateTime.month().day().hour())))
+                                        BigCard(title: event.title, subtitle: LocalizedStringKey(event.shortDescription), imageURL: smallerImage(for: event.imageUrl), bottomOverlay: Text(event.startDate.formatted(.dateTime.month().day().hour())))
                                             .frame(width: 300)
                                     }
                                     .foregroundStyle(.primary)
@@ -184,13 +184,13 @@ struct HomeScreen: View {
         .navigationDestination(for: ContentType.self) { content in
             switch content {
                 case .exhibitions:
-                    ExhibitionsGridView(exhibitions: exhibitions)
+                    ExhibitionsGridView(exhibitions: AppDataManager.sharedInstance.exhibitions)
                         .environmentObject(coordinator)
                 case .events:
-                    EventsGridView(events: events)
+                    EventsGridView(events: AppDataManager.sharedInstance.events)
                         .environmentObject(coordinator)
                 case .tours:
-                    ToursGridView(tours: tours)
+                    ToursGridView(tours: AppDataManager.sharedInstance.getToursForSeeAll())
                         .environmentObject(coordinator)
             }
         }
@@ -213,6 +213,10 @@ extension HomeScreen {
     
     private var tours: [AICTourModel] {
         AppDataManager.sharedInstance.getToursForHome()
+    }
+    
+    private func smallerImage(for url: URL) -> URL {
+        url.updatingQueryItem(key: "w", value: "400").updatingQueryItem(key: "h", value: "225)")
     }
     
     private var title: String {

--- a/aic/aic.xcodeproj/project.pbxproj
+++ b/aic/aic.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		8D4F9A012F8827F300200C56 /* HomeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4F9A002F8827F300200C56 /* HomeNavigationCoordinator.swift */; };
 		8D4F9A032F8827F300200C56 /* InfoNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4F9A042F8827F300200C56 /* InfoNavigationCoordinator.swift */; };
 		8D5960C32F84516E00267530 /* MemberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5960C22F84516E00267530 /* MemberView.swift */; };
+		8D7E3AA12FA39A4300F71266 /* URL+AIC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7E3AA02FA39A4300F71266 /* URL+AIC.swift */; };
 		8D919A752DD9363800FED627 /* GeneralCrashlyticsReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D919A742DD9363800FED627 /* GeneralCrashlyticsReport.swift */; };
 		8D9F2EC82F76D572008AEF5D /* LanguageSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9F2EC72F76D572008AEF5D /* LanguageSettingsView.swift */; };
 		8D9F2EC92F76D572008AEF5D /* LanguageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9F2EC62F76D572008AEF5D /* LanguageManager.swift */; };
@@ -442,6 +443,7 @@
 		8D4F9A002F8827F300200C56 /* HomeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		8D4F9A042F8827F300200C56 /* InfoNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoNavigationCoordinator.swift; sourceTree = "<group>"; };
 		8D5960C22F84516E00267530 /* MemberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberView.swift; sourceTree = "<group>"; };
+		8D7E3AA02FA39A4300F71266 /* URL+AIC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+AIC.swift"; sourceTree = "<group>"; };
 		8D919A742DD9363800FED627 /* GeneralCrashlyticsReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCrashlyticsReport.swift; sourceTree = "<group>"; };
 		8D9F2EC62F76D572008AEF5D /* LanguageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageManager.swift; sourceTree = "<group>"; };
 		8D9F2EC72F76D572008AEF5D /* LanguageSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSettingsView.swift; sourceTree = "<group>"; };
@@ -958,6 +960,7 @@
 				E421782F1CC57BE200815B41 /* UITextView+AIC.swift */,
 				E2C72F0729C3EFA30021F1EC /* UIViewController+ChildTransition.swift */,
 				E260C3AF2B751728004911C4 /* Bundle+ApplicationInfo.swift */,
+				8D7E3AA02FA39A4300F71266 /* URL+AIC.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1485,6 +1488,7 @@
 				E4F82F6E1CA45F3400E4224B /* SectionViewController.swift in Sources */,
 				294C0B4F201A76F700F2ABB1 /* MapObjectAnnotationView.swift in Sources */,
 				E411DE811CCD50BE00E22047 /* AICTourStopModel.swift in Sources */,
+				8D7E3AA12FA39A4300F71266 /* URL+AIC.swift in Sources */,
 				E497FA5C1CFF3803007FA272 /* AICAppDataModel.swift in Sources */,
 				294C0B57201A76F700F2ABB1 /* MapImageAnnotation.swift in Sources */,
 				29AC501A2059C4210085EE5B /* AICTourCategoryModel.swift in Sources */,

--- a/aic/aic/Models/AICBuildingHours.swift
+++ b/aic/aic/Models/AICBuildingHours.swift
@@ -120,7 +120,6 @@ struct AICBuildingHours: Decodable {
     }
 }
 
-#if DEBUG
 extension AICBuildingHours {
     static var preview: AICBuildingHours {
         AICBuildingHours(data: [
@@ -167,4 +166,3 @@ extension AICBuildingHours {
         ])
     }
 }
-#endif

--- a/aic/aic/Shared/Extensions/URL+AIC.swift
+++ b/aic/aic/Shared/Extensions/URL+AIC.swift
@@ -1,0 +1,29 @@
+//
+//  URL+AIC.swift
+//  aic
+//
+//  Created by David Bireta on 4/30/26.
+//  Copyright © 2026 Art Institute of Chicago. All rights reserved.
+//
+
+import Foundation
+
+extension URL {
+    
+    /// Replaces the value of query parameters.
+    /// - Parameters:
+    ///   - key: The name of the query paramter to update
+    ///   - value: The new value of the query paramter
+    /// - Returns: A `URL` with the query parameter updated, if it exists. Else it returns the original URL.
+    func updatingQueryItem(key: String, value: String) -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return self
+        }
+        
+        if let index = components.queryItems?.firstIndex(where: { $0.name == key }) {
+            components.queryItems?[index] = URLQueryItem(name: key, value: value)
+        }
+        
+        return components.url ?? self
+    }
+}


### PR DESCRIPTION
Based on a [great suggestion from Nikhil](https://github.com/art-institute-of-chicago/aic-mobile-ios/pull/90#discussion_r3125670050), this PR adds a new URL extension to help match the images sizes used by the website. Hopefully this should help to increase the chance of hitting the image cache when requesting thumbnails.

If the image quality still looks good, we could expand this for Exhibitions and Tours.