### PR TITLE
Remove unnecessary call to startLoadingData().

### DIFF
--- a/aic/aic/ViewControllers+Views/RootViewController.swift
+++ b/aic/aic/ViewControllers+Views/RootViewController.swift
@@ -136,7 +136,6 @@ private extension RootViewController {
   func setup() {
     registerSettingsBundle()
     setupDelegate()
-    startLoadingData()
   }
 
   func startLoadingData() {


### PR DESCRIPTION
With the recent change to adopt the Scene-based app lifecycle (to support the Member Card quick action), the call to startLoadingData was accidentally being made twice. This would sometimes result in a  race condition while downloading the map PDFs, which would display an error message.